### PR TITLE
download-artifact: paginate workflow response

### DIFF
--- a/.github/workflows/download-artifact-download.yml
+++ b/.github/workflows/download-artifact-download.yml
@@ -1,6 +1,7 @@
 name: Download
 
 on:
+  pull_request: []
   push:
     branches:
       - master

--- a/.github/workflows/git-ssh.yml
+++ b/.github/workflows/git-ssh.yml
@@ -2,7 +2,6 @@ name: Test `git-ssh` action.
 
 on:
   - push
-  - pull_request
 
 jobs:
   setup_ssh_key:

--- a/download-artifact/main.js
+++ b/download-artifact/main.js
@@ -54,14 +54,21 @@ async function main() {
         console.log("==> Commit:", commit)
 
         // https://github.com/octokit/routes/issues/665
-        const runs = await client.actions.listWorkflowRunsFixed({
+        const options = client.actions.listWorkflowRunsFixed.endpoint.merge({
             ...github.context.repo,
-            workflow_id: workflow,
+            workflow_id: workflow
         })
 
-        const run = runs.data.workflow_runs.find((run) => {
-            return run.head_sha == commit
-        })
+        let run
+        for await (const response of client.paginate.iterator(options)) {
+            const matching_run = response.data.workflow_runs.find((workflow_run) => {
+                return workflow_run.head_sha == commit
+            })
+            if (matching_run) {
+                run = matching_run
+                break
+            }
+        }
 
         console.log("==> Run:", run.id)
 


### PR DESCRIPTION
By default, the rest.js API only returns 30 results. Using `await` pagination should let us find older workflow runs.