### PR TITLE
download-artifact: Fix deprecation warning

### DIFF
--- a/download-artifact/main.js
+++ b/download-artifact/main.js
@@ -59,7 +59,7 @@ async function main() {
 
         let run
         for await (const response of client.paginate.iterator(options)) {
-            const matching_run = response.data.workflow_runs.find((workflow_run) => {
+            const matching_run = response.data.find((workflow_run) => {
                 return workflow_run.head_sha == commit
             })
             if (matching_run) {


### PR DESCRIPTION
- I saw this in the Homebrew/linuxbrew-core Actions logs:

```
[@octokit/paginate-rest] "response.data.workflow_runs" is deprecated for "GET /repos/Homebrew/linuxbrew-core/actions/workflows/build-bottles.yml/runs". Get the results directly from "response.data"
```