### PR TITLE
workflows: use actions/upload-artifact v2

### DIFF
--- a/.github/workflows/download-artifact-upload.yml
+++ b/.github/workflows/download-artifact-upload.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: artifact
           path: ./download-artifact/


### PR DESCRIPTION
Use upload-artifact v2

release note, https://github.com/actions/upload-artifact/releases/tag/v2

> - Port entire action to typescript from a runner plugin so it is easier to collaborate and accept contributions
> - Upload artifacts using a wildcard pattern
> - Fix for artifact uploads sometimes not working with containers
> - Upload an artifact without providing a name

