### PR TITLE
Add label-pull-requests Action

### DIFF
--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,0 +1,31 @@
+name: Label pull requests
+
+on:
+  push:
+    paths:
+      - '**label-pull-requests**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'node_modules/**'
+
+jobs:
+  label-pull-requests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Test
+        uses: ./label-pull-requests/
+        with:
+          def: |
+            [
+              {
+                "label": "wontfix",
+                "path": "deadbeef",
+                "content": "deadbeef"
+              }
+            ]
+      - name: Unlabel
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh api -X DELETE repos/$GITHUB_REPOSITORY/issues/21/labels/wontfix

--- a/label-pull-requests/README.md
+++ b/label-pull-requests/README.md
@@ -1,0 +1,25 @@
+# Label pull requests GitHub Action
+
+An action that labels latest pull requests with given criteria.
+
+## Usage
+
+```yaml
+- name: Label PRs
+  uses: Homebrew/actions/label-pull-requests@master
+  with:
+    token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+    def: |
+      [
+          {
+              "label": "new formula",
+              "status": "added",
+              "path": "Formula/.+"
+          },
+          {
+              "label": "bottle unneeded",
+              "content": "bottle :unneeded",
+              "path": "Formula/.+"
+          }
+      ]
+```

--- a/label-pull-requests/action.yml
+++ b/label-pull-requests/action.yml
@@ -15,7 +15,7 @@ inputs:
 
       It's an array of objects containing the following fields:
         - "label" (required): Label name, that should be added to PR
-        - "status" (optional): File status, one of: added, modified, changed
+        - "status" (optional): File status, one of: added, modified, removed
         - "path" (optional): Changed file path, regex matching
         - "content" (optional): Changed file content, regex matching
 

--- a/label-pull-requests/action.yml
+++ b/label-pull-requests/action.yml
@@ -1,0 +1,36 @@
+name: Label pull requests
+description: Label pull requests with specified criteria
+author: dawidd6
+branding:
+  icon: tag
+  color: blue
+inputs:
+  token:
+    description: GitHub token
+    required: false
+    default: ${{github.token}}
+  def:
+    description: |
+      Definition in JSON format.
+
+      It's an array of objects containing the following fields:
+        - "label" (required): Label name, that should be added to PR
+        - "status" (optional): File status, one of: added, modified, changed
+        - "path" (optional): Changed file path, regex matching
+        - "content" (optional): Changed file content, regex matching
+
+      Example:
+        [
+          {
+            "label": "new formula",
+            "status": "added",
+            "path": "Formula/.+"
+          }, {
+            "label": "bottle unneeded",
+            "content": "bottle :unneeded"
+          }
+        ]
+    required: true
+runs:
+  using: node12
+  main: main.js

--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -1,0 +1,97 @@
+const core = require('@actions/core')
+const github = require('@actions/github')
+const fs = require("fs")
+
+async function main() {
+    try {
+        const token = core.getInput("token", { required: true })
+        const def = core.getInput("def", { required: true })
+
+        // Parse definition
+        const constraints = JSON.parse(def)
+
+        // Lint constraints
+        for (const constraint of constraints) {
+            if (!constraint.label) {
+                console.log(constraint)
+                core.setFailed("missing label in constraint")
+                return
+            }
+        }
+
+        const client = github.getOctokit(token)
+
+        // Fetch latest 30 open PRs
+        const pulls = await client.pulls.list({
+            ...github.context.repo,
+            state: "open",
+            per_page: 30
+        })
+
+        for (const pull of pulls.data) {
+            console.log(`==> #${pull.number}: ${pull.title}`)
+
+            let existingLabels = pull.labels.map(label => label.name)
+            let wantedLabels = []
+
+            // Fetch PR files
+            const files = await client.pulls.listFiles({
+                ...github.context.repo,
+                pull_number: pull.number
+            });
+
+            for (const file of files.data) {
+                // Fetch file content
+                const blob = await client.git.getBlob({
+                    ...github.context.repo,
+                    file_sha: file.sha
+                })
+
+                // Decode received base64-encoded file content
+                const buffer = Buffer.from(blob.data.content, blob.data.encoding)
+                const content = buffer.toString('ascii')
+
+                // Match constraints
+                for (const constraint of constraints) {
+                    if (constraint.status && (file.status != constraint.status)) {
+                        continue
+                    }
+                    if (constraint.path && (!file.filename.match(constraint.path))) {
+                        continue
+                    }
+                    if (constraint.content && (!content.match(constraint.content))) {
+                        continue
+                    }
+                    if (existingLabels.includes(constraint.label)) {
+                        continue
+                    }
+                    if (wantedLabels.includes(constraint.label)) {
+                        continue
+                    }
+
+                    console.log(constraint)
+
+                    wantedLabels.push(constraint.label)
+                }
+            }
+
+            // No constraints matched, continue ...
+            if (wantedLabels.length == 0) {
+                continue
+            }
+
+            console.log(wantedLabels)
+
+            // Add wanted labels to PR
+            await client.issues.addLabels({
+                ...github.context.repo,
+                issue_number: pull.number,
+                labels: wantedLabels
+            })
+        }
+    } catch (error) {
+        core.setFailed(error.message)
+    }
+}
+
+main()

--- a/label-pull-requests/package.json
+++ b/label-pull-requests/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "label-pull-requests",
+  "main": "main.js"
+}


### PR DESCRIPTION
Per discussion here: https://github.com/Homebrew/brew/issues/7805

This PR adds an Action which labels pull requests when specified criteria match.

It makes a lot of API calls right now, cause it needs to first fetch list of open PRs, then fetch a list of changed files for each of those PRs and then fetch every changed file's content. But this way it is very flexible.

I went for JSON format as a criteria definition, as it is the easiest to implement with NodeJS, but I'm open for suggestions.
Also embedding JSON document in YAML isn't very friendly and sane, I know. Initially I thought about making a _custom DSL_ a'la GitHub search, like: `label:new formula,status:added,path:Formula/.+`, but abandoned it, as it required more work and I wanted to have a _working idea_ faster.