### PR TITLE
label-pull-requests: refactor and match all files

### DIFF
--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -1,6 +1,5 @@
 const core = require('@actions/core')
 const github = require('@actions/github')
-const fs = require("fs")
 
 async function main() {
     try {
@@ -19,6 +18,8 @@ async function main() {
             }
         }
 
+        core.info(`==> Fetching data...\n`)
+
         const client = github.getOctokit(token)
 
         // Fetch latest XX open PRs
@@ -28,18 +29,21 @@ async function main() {
             per_page: 50
         })
 
+        // Map pull request object to its files
+        const pullToFiles = new Map()
+
+        // Fetch data and store it in the map
         for (const pull of pulls.data) {
-            console.log(`==> #${pull.number}: ${pull.title}`)
-
-            let existingLabels = pull.labels.map(label => label.name)
-            let wantedLabels = []
-
             // Fetch PR files
             const files = await client.pulls.listFiles({
                 ...github.context.repo,
                 pull_number: pull.number
-            });
+            })
 
+            // Map pull to files
+            pullToFiles.set(pull, files.data)
+
+            // Enhance every file object with its content
             for (const file of files.data) {
                 // Fetch file content
                 const blob = await client.git.getBlob({
@@ -51,42 +55,79 @@ async function main() {
                 const buffer = Buffer.from(blob.data.content, blob.data.encoding)
                 const content = buffer.toString('ascii')
 
-                // Match constraints
+                file.content = content
+            }
+        }
+
+        // Sweep map
+        for (const pullAndFiles of pullToFiles) {
+            const pull = pullAndFiles[0]
+            const pullFiles = pullAndFiles[1]
+            const pullLabels = pull.labels.map(label => label.name)
+
+            // Map constraint to an array of matching files objects
+            const constraintToMatchingFiles = new Map()
+
+            // Match files with given constraints
+            for (const file of pullFiles) {
                 for (const constraint of constraints) {
+                    // Do nothing if PR already has the label
+                    if (pullLabels.includes(constraint.label)) {
+                        continue
+                    }
+
                     if (constraint.status && (file.status != constraint.status)) {
                         continue
                     }
                     if (constraint.path && (!file.filename.match(constraint.path))) {
                         continue
                     }
-                    if (constraint.content && (!content.match(constraint.content))) {
-                        continue
-                    }
-                    if (existingLabels.includes(constraint.label)) {
-                        continue
-                    }
-                    if (wantedLabels.includes(constraint.label)) {
+                    if (constraint.content && (!file.content.match(constraint.content))) {
                         continue
                     }
 
-                    console.log(constraint)
+                    // Init map key if not found
+                    if (!constraintToMatchingFiles.has(constraint)) {
+                        constraintToMatchingFiles.set(constraint, [])
+                    }
 
-                    wantedLabels.push(constraint.label)
+                    // Append file to array
+                    constraintToMatchingFiles.get(constraint).push(file)
                 }
             }
 
+            // Only consider labelling when all PR files match a constraint
+            for (const constraintAndMatchingFiles of constraintToMatchingFiles) {
+                const constraint = constraintAndMatchingFiles[0]
+                const matchingFiles = constraintAndMatchingFiles[1]
+
+                if (matchingFiles.length == pullFiles.length) {
+                    continue
+                }
+
+                constraintToMatchingFiles.delete(constraint)
+            }
+
+            // Get a list of distinct labels
+            const labels = Array.from(
+                new Set(
+                    Array.from(constraintToMatchingFiles.keys())
+                        .map(constraint => constraint.label)
+                )
+            )
+
             // No constraints matched, continue ...
-            if (wantedLabels.length == 0) {
+            if (labels.length == 0) {
                 continue
             }
 
-            console.log(`Labelling PR #${pull.number} with: [${wantedLabels}]`)
+            core.info(`==> Labelling PR #${pull.number} with [${labels}]`)
 
             // Add wanted labels to PR
             await client.issues.addLabels({
                 ...github.context.repo,
                 issue_number: pull.number,
-                labels: wantedLabels
+                labels: labels
             })
         }
     } catch (error) {


### PR DESCRIPTION
This PR refactors the Action in a way: first fetch data from API, then process it.

Also, it creates a new condition for labelling. Only if every file matches, label is added to PR.