### PR TITLE
workflows/setup-homebrew: run test-bot.

### DIFF
--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -32,5 +32,9 @@ jobs:
       - name: Install Homebrew Bundler RubyGems
         if: steps.cache.outputs.cache-hit != 'true'
         run: brew install-bundler-gems
-      - name: Test
-        run: brew config
+      - name: Run brew test-bot --only-cleanup-before
+        run: brew test-bot --only-cleanup-before
+      - name: Run brew test-bot --only-setup
+        run: brew test-bot --only-setup
+      - name: Run brew test-bot --only-tap-syntax
+        run: brew test-bot --only-tap-syntax

--- a/setup-homebrew/README.md
+++ b/setup-homebrew/README.md
@@ -27,3 +27,13 @@ This also sets up the variables necessary to cache the gems installed by Homebre
   if: steps.cache.outputs.cache-hit != 'true'
   run: brew install-bundler-gems
 ```
+
+If you're using Linux, it will be quicker to use the GitHub Actions provided Ruby:
+
+```yaml
+- name: Set up Ruby
+  if: matrix.os == 'ubuntu-latest'
+  uses: actions/setup-ruby@master
+  with:
+    ruby-version: '2.6'
+```

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -59,6 +59,8 @@ elif [[ "$GITHUB_REPOSITORY" =~ ^.+/homebrew-.+$ ]]; then
     ln -vs "$GITHUB_WORKSPACE" "$HOMEBREW_TAP_REPOSITORY"
 fi
 
+brew tap homebrew/test-bot
+
 if [[ "$RUNNER_OS" = "Linux" ]]; then
     sudo chown -R "$(whoami)" "$HOMEBREW_PREFIX"
     sudo chmod -R g-w,o-w "$HOMEBREW_CORE_REPOSITORY"


### PR DESCRIPTION
This is a better test because:

- it runs `brew config` for us
- this is what we're expecting users to run
- this is/shortly will be what `brew tap-new` is doing