### PR TITLE
setup-homebrew/main.sh: chown HOMEBREW_PREFIX.

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -72,5 +72,5 @@ fi
 
 if [[ "$RUNNER_OS" = "Linux" ]]; then
     sudo chown -R "$(whoami)" "$HOMEBREW_PREFIX"
-    sudo chmod -R g-w,o-w "$HOMEBREW_CORE_REPOSITORY"
+    sudo chmod -R g-w,o-w "$HOMEBREW_PREFIX" "$HOMEBREW_CORE_REPOSITORY"
 fi


### PR DESCRIPTION
Needed for `brew tests`.