### PR TITLE
setup-homebrew/main.sh: don't symlink workspace when self-hosted.

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -46,8 +46,10 @@ if [[ "$GITHUB_REPOSITORY" =~ ^.+/brew$ ]]; then
 # core taps
 elif [[ "$GITHUB_REPOSITORY" =~ ^.+/(home|linux)brew-core$ ]]; then
     cd "$HOMEBREW_CORE_REPOSITORY"
-    rm -rf "$GITHUB_WORKSPACE"
-    ln -vs "$HOMEBREW_CORE_REPOSITORY" "$GITHUB_WORKSPACE"
+    if [[ -z "$GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED" ]]; then
+        rm -rf "$GITHUB_WORKSPACE"
+        ln -vs "$HOMEBREW_CORE_REPOSITORY" "$GITHUB_WORKSPACE"
+    fi
     git remote set-url origin "https://github.com/$GITHUB_REPOSITORY"
     git fetch origin "$GITHUB_SHA"
     git checkout --force -B master FETCH_HEAD


### PR DESCRIPTION
In this situation we're not running the GitHub Actions "Set up Git" step so this will behave incorrectly.