### PR TITLE
setup-homebrew/main.sh: chown more directories.

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -72,5 +72,5 @@ fi
 
 if [[ "$RUNNER_OS" = "Linux" ]]; then
     sudo chown -R "$(whoami)" "$HOMEBREW_PREFIX"
-    sudo chmod -R g-w,o-w "$HOMEBREW_PREFIX" "$HOMEBREW_CORE_REPOSITORY"
+    sudo chmod -R g-w,o-w "$HOMEBREW_PREFIX" "$HOMEBREW_CORE_REPOSITORY" /home/runner /opt
 fi


### PR DESCRIPTION
We need all of those in the PATH to be not-group-writable.