### PR TITLE
setup-homebrew/main.sh: handle unbound variable.

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -46,7 +46,7 @@ if [[ "$GITHUB_REPOSITORY" =~ ^.+/brew$ ]]; then
 # core taps
 elif [[ "$GITHUB_REPOSITORY" =~ ^.+/(home|linux)brew-core$ ]]; then
     cd "$HOMEBREW_CORE_REPOSITORY"
-    if [[ -z "$GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED" ]]; then
+    if [[ -z "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-}" ]]; then
         rm -rf "$GITHUB_WORKSPACE"
         ln -vs "$HOMEBREW_CORE_REPOSITORY" "$GITHUB_WORKSPACE"
     fi


### PR DESCRIPTION
GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED is not necessarily defined.