### PR TITLE
setup-homebrew: fix Bash syntax error.

### DIFF
--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
+      - name: Check syntax
+        run: bash -n setup-homebrew/*.sh
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: ./setup-homebrew/

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -70,7 +70,7 @@ fi
 HOMEBREW_TEST_BOT_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-test-bot"
 if [[ -d "HOMEBREW_TEST_BOT_REPOSITORY" ]]; then
     git clone --depth=1 https://github.com/Homebrew/homebrew-test-bot "$HOMEBREW_TEST_BOT_REPOSITORY"
-elsif [[ "$GITHUB_REPOSITORY" != "Homebrew/homebrew-test-bot" ]]
+elif [[ "$GITHUB_REPOSITORY" != "Homebrew/homebrew-test-bot" ]]; then
     brew update-reset "$HOMEBREW_TEST_BOT_REPOSITORY"
 fi
 


### PR DESCRIPTION
This wasn't caught by CI so add a test to check these in future.