### PR TITLE
setup-homebrew: more tweaks.

### DIFF
--- a/setup-homebrew/README.md
+++ b/setup-homebrew/README.md
@@ -28,12 +28,4 @@ This also sets up the variables necessary to cache the gems installed by Homebre
   run: brew install-bundler-gems
 ```
 
-If you're using Linux, it will be quicker to use the GitHub Actions provided Ruby:
-
-```yaml
-- name: Set up Ruby
-  if: matrix.os == 'ubuntu-latest'
-  uses: actions/setup-ruby@master
-  with:
-    ruby-version: '2.6'
-```
+Note you do not need to use the `actions/setup-ruby` or `actions/checkout` steps because this action will install the necessary Ruby for Homebrew and checkout the repository being tested.


### PR DESCRIPTION
- Remove mention of `actions/setup-ruby` and note that it and `actions/checkout` are unnecessary when using this action.
- Only run `brew update-reset` on Homebrew/brew or Homebrew/homebrew-core when necessary (to improve speed).
- Handle self-hosted workers on Homebrew/brew and refuse to use them on non-homebrew-core taps.
- Fetch and checkout the right version of a tested tap.
- Fix Homebrew/homebrew-test-bot configuration so it is not cloned unless necessary (and is when it is).
- Add more comments.