### PR TITLE
setup-homebrew/main.sh: handle missing tap.

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -73,12 +73,17 @@ else
         fi
 
         HOMEBREW_TAP_REPOSITORY="$(brew --repo "$GITHUB_REPOSITORY")"
-        mkdir -vp "$HOMEBREW_TAP_REPOSITORY"
-        cd "$HOMEBREW_TAP_REPOSITORY"
+        if [[ -d "$HOMEBREW_TAP_REPOSITORY" ]]; then
+            cd "$HOMEBREW_TAP_REPOSITORY"
+            git remote set-url origin "https://github.com/$GITHUB_REPOSITORY"
+        else
+            mkdir -vp "$HOMEBREW_TAP_REPOSITORY"
+            cd "$HOMEBREW_TAP_REPOSITORY"
+            git init
+            git remote add origin "https://github.com/$GITHUB_REPOSITORY"
+        fi
         rm -rf "$GITHUB_WORKSPACE"
         ln -vs "$HOMEBREW_TAP_REPOSITORY" "$GITHUB_WORKSPACE"
-        git init
-        git remote set-url origin "https://github.com/$GITHUB_REPOSITORY"
         git fetch origin "$GITHUB_SHA"
         git checkout --force -B master FETCH_HEAD
         cd -


### PR DESCRIPTION
Need to use `git remote add origin` in this case.