### PR TITLE
setup-homebrew/main.sh: fix test-bot variable.

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -94,7 +94,7 @@ fi
 
 # Setup Homebrew/homebrew-test-bot
 HOMEBREW_TEST_BOT_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-test-bot"
-if ! [[ -d "HOMEBREW_TEST_BOT_REPOSITORY" ]]; then
+if ! [[ -d "$HOMEBREW_TEST_BOT_REPOSITORY" ]]; then
     git clone --depth=1 https://github.com/Homebrew/homebrew-test-bot "$HOMEBREW_TEST_BOT_REPOSITORY"
 elif [[ "$GITHUB_REPOSITORY" != "Homebrew/homebrew-test-bot" ]]; then
     brew update-reset "$HOMEBREW_TEST_BOT_REPOSITORY"


### PR DESCRIPTION
Otherwise this will always attempt to clone (causing failures on the Homebrew/homebrew-test-bot repository).