### PR TITLE
git-try-push: use `git pull --rebase --autostash`.

### DIFF
--- a/git-try-push/main.js
+++ b/git-try-push/main.js
@@ -42,7 +42,7 @@ async function main() {
                 // and try again.
                 const delay = i**2
                 await exec.exec("sleep", [delay])
-                await exec.exec("git", ["pull", "--rebase", remote, branch])
+                await exec.exec("git", ["pull", "--rebase", "--autostash", remote, branch])
             }
         }
 


### PR DESCRIPTION
This means that we can get updates without needing to manual run stash or having a clean tree.