### PR TITLE
label-pull-requests: support only pull_request* events

### DIFF
--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,7 +1,7 @@
 name: Label pull requests
 
 on:
-  push:
+  pull_request:
     paths:
       - '**label-pull-requests**'
       - 'package.json'
@@ -22,12 +22,12 @@ jobs:
             [
               {
                 "label": "wontfix",
-                "path": "deadbeef",
-                "content": "deadbeef"
+                "path": ".+"
               }
             ]
 
       - name: Unlabel
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: gh api -X DELETE repos/$GITHUB_REPOSITORY/issues/21/labels/wontfix
+          PR: ${{github.event.pull_request.number}}
+        run: gh api -X DELETE repos/$GITHUB_REPOSITORY/issues/$PR/labels/wontfix

--- a/label-pull-requests/README.md
+++ b/label-pull-requests/README.md
@@ -1,13 +1,13 @@
 # Label pull requests GitHub Action
 
-An action that labels latest pull requests with given criteria.
+An action that labels the pull request with given criteria.
 
-Will remove labels from pull requests that no longer apply.
+Will remove labels from a pull request that no longer apply.
 
 ## Usage
 
 ```yaml
-- name: Label PRs
+- name: Label PR
   uses: Homebrew/actions/label-pull-requests@master
   with:
     token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}

--- a/label-pull-requests/action.yml
+++ b/label-pull-requests/action.yml
@@ -1,5 +1,5 @@
 name: Label pull requests
-description: Label pull requests with specified criteria
+description: Label the pull request with specified criteria
 author: dawidd6
 branding:
   icon: tag

--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -1,5 +1,6 @@
 const core = require('@actions/core')
 const github = require('@actions/github')
+const fs = require('fs')
 
 async function main() {
     try {
@@ -20,147 +21,133 @@ async function main() {
 
         const client = github.getOctokit(token)
 
-        // Fetch latest XX open PRs
-        const pulls = await client.pulls.list({
+        // Parse event
+        const json = fs.readFileSync(process.env.GITHUB_EVENT_PATH, { encoding: "utf-8" })
+        const event = JSON.parse(json)
+        const pull = event.pull_request
+
+        // Fetch PR files
+        const files = await client.pulls.listFiles({
             ...github.context.repo,
-            state: "open",
-            per_page: 50
+            pull_number: pull.number
         })
 
-        // Map pull request object to its files objects
-        const pullToFiles = new Map()
-
-        // Fetch data and store it in the map
-        for (const pull of pulls.data) {
-            // Fetch PR files
-            const files = await client.pulls.listFiles({
-                ...github.context.repo,
-                pull_number: pull.number
-            })
-
-            // Map pull object to files object
-            pullToFiles.set(pull, files.data)
-
-            // Extend every file object with its content
-            for (const file of files.data) {
-                // File object could have this field set as 'null'
-                if (!file.sha) {
-                    file.content = ""
-                    continue
-                }
-
-                // Fetch file content
-                const blob = await client.git.getBlob({
-                    ...github.context.repo,
-                    file_sha: file.sha
-                })
-
-                // Decode received base64-encoded file content
-                const buffer = Buffer.from(blob.data.content, blob.data.encoding)
-                const content = buffer.toString('ascii')
-
-                file.content = content
-            }
-        }
-
-        // Sweep map
-        for (const pullAndFiles of pullToFiles) {
-            const pull = pullAndFiles[0]
-            const pullFiles = pullAndFiles[1]
-            const pullLabels = pull.labels.map(label => label.name)
-
-            // Map constraint to an array of matching files objects
-            const constraintToMatchingFiles = new Map()
-
-            // Match files with given constraints
-            for (const file of pullFiles) {
-                for (const constraint of constraints) {
-                    let constraintApplies = false
-                    let labelExists = false
-
-                    // Possible unwanted label
-                    if (pullLabels.includes(constraint.label)) {
-                        labelExists = true
-                    }
-
-                    // Check constraints
-                    if (
-                        (!constraint.status || file.status == constraint.status) &&
-                        (!constraint.path || file.filename.match(constraint.path)) &&
-                        (!constraint.content || file.content.match(constraint.content)) &&
-                        (!constraint.missing_content || !file.content.match(constraint.missing_content))
-                    ) {
-                        constraintApplies = true
-                    }
-
-                    if (labelExists && constraintApplies) {
-                        continue
-                    }
-                    if (!labelExists && !constraintApplies) {
-                        continue
-                    }
-
-                    // Unwanted label
-                    if (labelExists && !constraintApplies) {
-                        constraint.wanted = false
-                    }
-
-                    // Wanted label
-                    if (!labelExists && constraintApplies) {
-                        constraint.wanted = true
-                    }
-
-                    // Init map key if not found
-                    if (!constraintToMatchingFiles.has(constraint)) {
-                        constraintToMatchingFiles.set(constraint, [])
-                    }
-
-                    // Append file to array
-                    constraintToMatchingFiles.get(constraint).push(file)
-                }
-            }
-
-            // Only consider labelling when all PR files match a constraint
-            for (const constraintAndMatchingFiles of constraintToMatchingFiles) {
-                const constraint = constraintAndMatchingFiles[0]
-                const matchingFiles = constraintAndMatchingFiles[1]
-
-                if (matchingFiles.length == pullFiles.length) {
-                    continue
-                }
-
-                constraintToMatchingFiles.delete(constraint)
-            }
-
-            const pullLabelsNew = pullLabels.slice()
-
-            // Determine which labels should be added or deleted
-            for (const constraint of constraintToMatchingFiles.keys()) {
-                if (constraint.wanted && !pullLabelsNew.includes(constraint.label)) {
-                    pullLabelsNew.push(constraint.label)
-                }
-                if (!constraint.wanted) {
-                    const index = pullLabelsNew.indexOf(constraint.label);
-                    if (index > -1) {
-                        pullLabelsNew.splice(index, 1);
-                    }
-                }
-            }
-
-            // No constraints matched, continue ...
-            if (pullLabels.length == pullLabelsNew.length && pullLabels.every((label, i) => label == pullLabelsNew[i])) {
+        // Extend every file object with its content
+        for (const file of files.data) {
+            // File object could have this field set as 'null'
+            if (!file.sha) {
+                file.content = ""
                 continue
             }
 
-            core.info(`==> #${pull.number}: [${pullLabels}] => [${pullLabelsNew}]`)
-
-            // Update PR labels
-            await client.issues.update({
+            // Fetch file content
+            const blob = await client.git.getBlob({
                 ...github.context.repo,
-                issue_number: pull.number,
-                labels: pullLabelsNew
+                file_sha: file.sha
             })
+
+            // Decode received base64-encoded file content
+            const buffer = Buffer.from(blob.data.content, blob.data.encoding)
+            const content = buffer.toString('ascii')
+
+            file.content = content
         }
+
+        // Get existing labels on PR
+        const existingLabels = pull.labels.map(label => label.name)
+
+        // Map constraint to an array of matching files objects
+        const constraintToMatchingFiles = new Map()
+
+        // Match files with given constraints
+        for (const file of files.data) {
+            for (const constraint of constraints) {
+                let constraintApplies = false
+                let labelExists = false
+
+                // Possible unwanted label
+                if (existingLabels.includes(constraint.label)) {
+                    labelExists = true
+                }
+
+                // Check constraints
+                if (
+                    (!constraint.status || file.status == constraint.status) &&
+                    (!constraint.path || file.filename.match(constraint.path)) &&
+                    (!constraint.content || file.content.match(constraint.content)) &&
+                    (!constraint.missing_content || !file.content.match(constraint.missing_content))
+                ) {
+                    constraintApplies = true
+                }
+
+                if (labelExists && constraintApplies) {
+                    continue
+                }
+                if (!labelExists && !constraintApplies) {
+                    continue
+                }
+
+                // Unwanted label
+                if (labelExists && !constraintApplies) {
+                    constraint.wanted = false
+                }
+
+                // Wanted label
+                if (!labelExists && constraintApplies) {
+                    constraint.wanted = true
+                }
+
+                // Init map key if not found
+                if (!constraintToMatchingFiles.has(constraint)) {
+                    constraintToMatchingFiles.set(constraint, [])
+                }
+
+                // Append file to array
+                constraintToMatchingFiles.get(constraint).push(file)
+            }
+        }
+
+        // Only consider labelling when all PR files match a constraint
+        for (const constraintAndMatchingFiles of constraintToMatchingFiles) {
+            const constraint = constraintAndMatchingFiles[0]
+            const matchingFiles = constraintAndMatchingFiles[1]
+
+            if (matchingFiles.length == files.data.length) {
+                continue
+            }
+
+            constraintToMatchingFiles.delete(constraint)
+        }
+
+        // Copy labels into new Array
+        const updatedLabels = existingLabels.slice()
+
+        // Determine which labels should be added or deleted
+        for (const constraint of constraintToMatchingFiles.keys()) {
+            if (constraint.wanted && !updatedLabels.includes(constraint.label)) {
+                updatedLabels.push(constraint.label)
+            }
+            if (!constraint.wanted) {
+                const index = updatedLabels.indexOf(constraint.label);
+                if (index > -1) {
+                    updatedLabels.splice(index, 1);
+                }
+            }
+        }
+
+        // No constraints matched, just return
+        if (existingLabels.length == updatedLabels.length && existingLabels.every((label, i) => label == updatedLabels[i])) {
+            return
+        }
+
+        core.info(`==> #${pull.number}: [${existingLabels}] => [${updatedLabels}]`)
+
+        // Update PR labels
+        await client.issues.update({
+            ...github.context.repo,
+            issue_number: pull.number,
+            labels: updatedLabels
+        })
     } catch (error) {
         core.setFailed(error.message)
     }


### PR DESCRIPTION
This allows us to run this Action on pull_request_target event, rather than on schedule, which reduces API calls count and is faster.