### PR TITLE
Add `debug` input for `setup-homebrew`.

### DIFF
--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Install the `homebrew/test-bot` tap.
     required: false
     default: true
+  debug:
+    description: Show debugging output
+    required: false
+    default: false
 outputs:
   gems-path:
     description: Homebrew's Ruby gems path
@@ -20,6 +24,6 @@ runs:
   using: composite
   steps:
     - run: |
-        "$GITHUB_ACTION_PATH/main.sh" '${{ inputs.test-bot }}'
+        "$GITHUB_ACTION_PATH/main.sh" '${{ inputs.test-bot }}' '${{ inputs.debug }}'
       shell: bash
       id: setup

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -3,6 +3,11 @@
 set -euo pipefail
 
 TEST_BOT="${1}"
+DEBUG="${2}"
+
+if [[ "${DEBUG}" == 'true' ]]; then
+  set -x
+fi
 
 # Clone Homebrew/brew and Homebrew/linuxbrew-core if necessary.
 if ! which brew &>/dev/null; then


### PR DESCRIPTION
Needed for debugging CI failures.