### PR TITLE
Improve detection of version increases by using the `before_comma` part.

### DIFF
--- a/review-cask-pr/review.rb
+++ b/review-cask-pr/review.rb
@@ -103,7 +103,11 @@ begin
 
     pr = GitHub.open_api("https://api.github.com/repos/#{owner}/#{repo}/pulls/#{number}")
 
-    JSON.pretty_generate(review_pull_request(pr))
+    review = review_pull_request(pr)
+    return unless review
+
+    puts review[:event]
+    puts review[:message]
   else
     raise "Unsupported GitHub Actions event: #{event_name.inspect}"
   end


### PR DESCRIPTION
This should handle cases such as https://github.com/Homebrew/homebrew-cask-versions/pull/9582.

cc @Homebrew/cask