### PR TITLE
label-pull-request: add `except`

### DIFF
--- a/label-pull-requests/README.md
+++ b/label-pull-requests/README.md
@@ -24,6 +24,14 @@ Will remove labels from a pull request that no longer apply.
               "path": "Formula/.+"
           },
           {
+              "label": "legacy",
+              "path": "Formula/.+@.+",
+              "except": [
+                  "Formula/python@3.8",
+                  "Formula/python@3.9"
+              ]
+          },
+          {
               "label": "missing license",
               "missing_content": "license \"[^"]+\"",
               "path": "Formula/.+"

--- a/label-pull-requests/action.yml
+++ b/label-pull-requests/action.yml
@@ -17,6 +17,7 @@ inputs:
         - "label" (required): Label name, that should be added to PR
         - "status" (optional): File status, one of: added, modified, removed
         - "path" (optional): Changed file path, regex matching
+        - "except" (optional): File path(s) to exclude
         - "content" (optional): Changed file content, regex matching
         - "missing_content" (optional): Missing file content, regex matching
 
@@ -29,6 +30,13 @@ inputs:
           }, {
             "label": "bottle unneeded",
             "content": "bottle :unneeded"
+          }, {
+            "label": "legacy",
+            "path": "Formula/.+@.+",
+            "except": [
+              "Formula/python@3.8",
+              "Formula/python@3.9"
+            ]
           }, {
             "label": "missing license",
             "missing_content": "license \"[^"]+\""

--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -74,6 +74,7 @@ async function main() {
                 if (
                     (!constraint.status || file.status == constraint.status) &&
                     (!constraint.path || file.filename.match(constraint.path)) &&
+                    (!constraint.except || (Array.isArray(constraint.except) ? constraint.except.includes(file.filename) : file.filename == constraint.except)) &&
                     (!constraint.content || file.content.match(constraint.content)) &&
                     (!constraint.missing_content || !file.content.match(constraint.missing_content))
                 ) {

--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -71,15 +71,7 @@ async function main() {
                 }
 
                 // Check constraints
-                if (
-                    (!constraint.status || file.status == constraint.status) &&
-                    (!constraint.path || file.filename.match(constraint.path)) &&
-                    (!constraint.except || (Array.isArray(constraint.except) ? constraint.except.includes(file.filename) : file.filename == constraint.except)) &&
-                    (!constraint.content || file.content.match(constraint.content)) &&
-                    (!constraint.missing_content || !file.content.match(constraint.missing_content))
-                ) {
-                    constraintApplies = true
-                }
+                constraintApplies = doesConstraintApply(constraint, file)
 
                 if (labelExists && constraintApplies) {
                     continue
@@ -152,6 +144,36 @@ async function main() {
     } catch (error) {
         core.setFailed(error.message)
     }
+}
+
+function doesConstraintApply(constraint, file) {
+    if (constraint.status && file.status != constraint.status) {
+        return false
+    }
+
+    if (constraint.path && !file.filename.match(constraint.path)) {
+        return false
+    }
+
+    if (constraint.except) {
+        if (Array.isArray(constraint.except)) {
+            if (constraint.except.includes(file.filename)) {
+                return false
+            }
+        } else if (file.filename == constraint.except) {
+            return false
+        }
+    }
+
+    if (constraint.content && !file.content.match(constraint.content)) {
+        return false
+    }
+
+    if (constraint.missing_content && file.content.match(constraint.missing_content)) {
+        return false
+    }
+
+    return true
 }
 
 main()


### PR DESCRIPTION
This adds an `except` field to `label-pull-request` that allows files to be excluded by absolute path, i.e. without regex

Example:

```json
{
    "label": "legacy",
    "path": "Formula/.+@.+",
    "except": [
        "Formula/python@3.8",
        "Formula/python@3.9"
    ]
}
```

Related: Homebrew/homebrew-core#61163