### PR TITLE
Fix cache path.

### DIFF
--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         os:
+          - macos-latest
           - ubuntu-latest
-          - macOS-latest
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout
@@ -29,7 +29,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -40,11 +40,11 @@ echo "::add-path::$HOMEBREW_PREFIX/bin"
 # Setup Homebrew/brew
 if [[ "$GITHUB_REPOSITORY" =~ ^.+/brew$ ]]; then
     cd "$HOMEBREW_REPOSITORY"
-    rm -rf "$GITHUB_WORKSPACE"
     if [[ -n "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-}" ]]; then
-        mkdir -vp "$GITHUB_WORKSPACE"
+        mkdir -vp "${GITHUB_WORKSPACE}"
     else
-        ln -vs "$HOMEBREW_REPOSITORY" "$GITHUB_WORKSPACE"
+        rm -rf "${GITHUB_WORKSPACE}"
+        ln -vs "${HOMEBREW_REPOSITORY}" "${GITHUB_WORKSPACE}"
     fi
     git remote set-url origin "https://github.com/$GITHUB_REPOSITORY"
     git fetch --tags origin "$GITHUB_SHA"
@@ -61,64 +61,80 @@ GEMS_HASH="$(shasum -a 256 "$HOMEBREW_REPOSITORY/Library/Homebrew/Gemfile.lock" 
 echo "::set-output name=gems-path::$GEMS_PATH"
 echo "::set-output name=gems-hash::$GEMS_HASH"
 
+set_up_repo() {
+  local name="${1}"
+  local path="${2}"
+  local commit="${3}"
+
+  if [[ -d "${path}" ]]; then
+    pushd "${path}"
+    git remote set-url origin "https://github.com/${name}"
+  else
+    mkdir -vp "${path}"
+    pushd "${path}"
+    git init
+    git remote add origin "https://github.com/${name}"
+  fi
+
+  git fetch origin "${commit}"
+  git checkout --force -B master FETCH_HEAD
+
+  popd
+}
+
+replace_workspace() {
+  local path="${1}"
+
+  pushd ~
+
+  rm -rf "${GITHUB_WORKSPACE}"
+  mv "${path}" "${GITHUB_WORKSPACE}"
+  ln -vs "${GITHUB_WORKSPACE}" "${path}"
+
+  popd
+}
+
 # Setup Homebrew/(home|linux)brew-core tap
 if [[ "$GITHUB_REPOSITORY" =~ ^.+/(home|linux)brew-core$ ]]; then
-    cd "$HOMEBREW_CORE_REPOSITORY"
-    rm -rf "$GITHUB_WORKSPACE"
-    if [[ -n "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-}" ]]; then
-        mkdir -vp "$GITHUB_WORKSPACE"
-    else
-        ln -vs "$HOMEBREW_CORE_REPOSITORY" "$GITHUB_WORKSPACE"
-    fi
-    git remote set-url origin "https://github.com/$GITHUB_REPOSITORY"
-    git fetch origin "$GITHUB_SHA"
-    git checkout --force -B master FETCH_HEAD
-    cd -
+  set_up_repo "${GITHUB_REPOSITORY}" "${HOMEBREW_CORE_REPOSITORY}" "${GITHUB_SHA}"
+
+  if [[ -n "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-}" ]]; then
+    mkdir -vp "${GITHUB_WORKSPACE}"
+  else
+    replace_workspace "${HOMEBREW_CORE_REPOSITORY}"
+  fi
 else
-    if [[ "$GITHUB_REPOSITORY" =~ ^.+/homebrew-.+$ ]]; then
-        if [[ -n "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-}" ]]; then
-            echo "Self-hosted runners not supported for this tap!"
-            exit 1
-        fi
+  if [[ "$GITHUB_REPOSITORY" =~ ^.+/homebrew-.+$ ]]; then
+    HOMEBREW_TAP_REPOSITORY="$(brew --repo "$GITHUB_REPOSITORY")"
 
-        HOMEBREW_TAP_REPOSITORY="$(brew --repo "$GITHUB_REPOSITORY")"
+    set_up_repo "${GITHUB_REPOSITORY}" "${HOMEBREW_TAP_REPOSITORY}" "${GITHUB_SHA}"
 
-        if [[ "$GITHUB_REPOSITORY" =~ ^.+/homebrew-cask(-.+)*$ ]]; then
-            # Tap or update homebrew/cask for other cask repos.
-            if [[ "${HOMEBREW_TAP_REPOSITORY}" != "${HOMEBREW_CASK_REPOSITORY}" ]] && [[ -d "${HOMEBREW_CASK_REPOSITORY}" ]]; then
-                brew update-reset "${HOMEBREW_CASK_REPOSITORY}"
-            else
-                brew tap homebrew/cask
-            fi
-
-            for cask_repo in \
-                "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask-drivers" \
-                "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask-fonts" \
-                "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask-versions"
-            do
-                if [[ "${HOMEBREW_TAP_REPOSITORY}" != "${cask_repo}" ]] && [[ -d "${cask_repo}" ]]; then
-                    brew update-reset "${cask_repo}"
-                fi
-            done
-        fi
-
-        if [[ -d "$HOMEBREW_TAP_REPOSITORY" ]]; then
-            cd "$HOMEBREW_TAP_REPOSITORY"
-            git remote set-url origin "https://github.com/$GITHUB_REPOSITORY"
-        else
-            mkdir -vp "$HOMEBREW_TAP_REPOSITORY"
-            cd "$HOMEBREW_TAP_REPOSITORY"
-            git init
-            git remote add origin "https://github.com/$GITHUB_REPOSITORY"
-        fi
-        rm -rf "$GITHUB_WORKSPACE"
-        ln -vs "$HOMEBREW_TAP_REPOSITORY" "$GITHUB_WORKSPACE"
-        git fetch origin "$GITHUB_SHA"
-        git checkout --force -B master FETCH_HEAD
-        cd -
+    if [[ -n "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-}" ]]; then
+      echo "Self-hosted runners not supported for this tap!"
+      exit 1
+    else
+      replace_workspace "${HOMEBREW_TAP_REPOSITORY}"
     fi
 
-    brew update-reset "$HOMEBREW_CORE_REPOSITORY"
+    if [[ "$GITHUB_REPOSITORY" =~ ^.+/homebrew-cask(-.+)*$ ]]; then
+      # Set up homebrew/cask for other cask repos.
+      if [[ "${HOMEBREW_TAP_REPOSITORY}" != "${HOMEBREW_CASK_REPOSITORY}" ]]; then
+        set_up_repo Homebrew/homebrew-cask "${HOMEBREW_CASK_REPOSITORY}" HEAD
+      fi
+
+      for cask_repo in \
+        "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask-drivers" \
+        "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask-fonts" \
+        "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask-versions"
+      do
+        if [[ "${HOMEBREW_TAP_REPOSITORY}" != "${cask_repo}" ]] && [[ -d "${cask_repo}" ]]; then
+          brew update-reset "${cask_repo}"
+        fi
+      done
+    fi
+  fi
+
+  brew update-reset "${HOMEBREW_CORE_REPOSITORY}"
 fi
 
 if [[ "${TEST_BOT}" == 'true' ]]; then
@@ -134,5 +150,5 @@ fi
 # Setup Linux permissions
 if [[ "$RUNNER_OS" = "Linux" ]]; then
     sudo chown -R "$(whoami)" "$HOMEBREW_PREFIX"
-    sudo chmod -R g-w,o-w /home/linuxbrew $HOME /opt
+    sudo chmod -R g-w,o-w /home/linuxbrew "${HOME}" /opt
 fi


### PR DESCRIPTION
Since we override `GITHUB_WORKSPACE`, the path we use for caching is wrong inside the `actions/cache@v2` action.

Problem:

The `cache` action will run inside of the resolved `GITHUB_WORKSPACE` path, i.e. in `HOMEBREW_REPOSITORY` or inside of a tap directory. The cache path is still resolved relative to the unresolved `GITHUB_WORKSPACE` variable.

Solution:

~~Set the `gems-path` output relative to the unresolved `GITHUB_WORKSPACE` instead of to an absolute path.~~

Reverse the link direction, so that `realpath` will be equal to `GITHUB_WORKSPACE`.