### PR TITLE
Only clone `homebrew/cask` if it doesn't exist.

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -108,7 +108,7 @@ else
             if [[ "${HOMEBREW_TAP_REPOSITORY}" != "${HOMEBREW_CASK_REPOSITORY}" ]] && [[ -d "${HOMEBREW_CASK_REPOSITORY}" ]]; then
                 git_retry -C "$HOMEBREW_CASK_REPOSITORY" fetch --force origin
                 git -C "$HOMEBREW_CASK_REPOSITORY" checkout --force -B master origin/HEAD
-            else
+            elif ! [[ -d "${HOMEBREW_CASK_REPOSITORY}" ]]; then
                 git_retry clone --depth=1 https://github.com/Homebrew/homebrew-cask "${HOMEBREW_CASK_REPOSITORY}"
             fi
 


### PR DESCRIPTION
https://github.com/Homebrew/actions/pull/94 broke CI for cask repos because while `brew tap` is idempotent, `git clone` isn't.

cc @MikeMcQuaid 