### PR TITLE
cancel-previous-runs: repurpose to run on pull_request event

### DIFF
--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -17,5 +17,3 @@ jobs:
 
       - name: Cancel
         uses: ./cancel-previous-runs
-        with:
-          workflow: cancel-previous-runs.yml

--- a/cancel-previous-runs/README.md
+++ b/cancel-previous-runs/README.md
@@ -7,7 +7,4 @@ An action that cancels all previous uncompleted duplicated workflow runs for a b
 ```yaml
 - name: Cancel previous runs
   uses: Homebrew/actions/cancel-previous-runs@master
-  with:
-    workflow: tests.yml
-    event: pull_request
 ```

--- a/cancel-previous-runs/action.yml
+++ b/cancel-previous-runs/action.yml
@@ -5,12 +5,6 @@ inputs:
     description: GitHub token
     required: false
     default: ${{github.token}}
-  workflow:
-    description: Workflow file name or ID
-    required: true
-  event:
-    description: Event that triggered the workflow run
-    required: false
 runs:
   using: node12
   main: main.js

--- a/cancel-previous-runs/main.js
+++ b/cancel-previous-runs/main.js
@@ -4,56 +4,65 @@ const github = require('@actions/github')
 async function main() {
     try {
         const token = core.getInput("token", { required: true })
-        const workflow = core.getInput("workflow", { required: true })
-        const event = core.getInput("event")
 
         const client = github.getOctokit(token)
 
-        const allRuns = await client.actions.listWorkflowRuns({
+        const repoWorkflowRuns = await client.actions.listWorkflowRunsForRepo({
             ...github.context.repo,
-            workflow_id: workflow,
-            event: event,
-            status: "in_progress OR queued"
+            status: "in_progress", // OR queued (but we have some ghost workflow runs)
+            per_page: 50
         })
 
-        const branchToRuns = new Map()
+        // Map branch to workflow ID to workflow runs
+        const branchToIDToRuns = new Map()
 
-        // Map branch to workflow runs
-        for (const run of allRuns.data.workflow_runs) {
-            if (run.status == "completed")
-              continue
+        for (const workflowRun of repoWorkflowRuns.data.workflow_runs) {
+            // GitHub can still return completed workflow runs, check it
+            if (workflowRun.status == "completed")
+                continue
+
+            // Check if conclusion is not null
+            if (workflowRun.conclusion)
+                continue
 
             // Make branch be in format "user:branch"
-            const branch = run.head_repository.owner.login + ":" + run.head_branch
+            const branch = workflowRun.head_repository.owner.login + ":" + workflowRun.head_branch
 
-            // Initialize array
-            if (!branchToRuns.has(branch))
-                branchToRuns.set(branch, [])
+            // Initialize nested map
+            if (!branchToIDToRuns.has(branch))
+                branchToIDToRuns.set(branch, new Map())
 
-            branchToRuns.get(branch).push(run)
+            // Initialize array of workflow runs
+            if (!branchToIDToRuns.get(branch).has(workflowRun.workflow_id))
+                branchToIDToRuns.get(branch).set(workflowRun.workflow_id, [])
+
+            branchToIDToRuns.get(branch).get(workflowRun.workflow_id).push(workflowRun)
         }
 
         // Iterate over map
-        for (const branchAndRuns of branchToRuns) {
-            const branch = branchAndRuns[0]
-            const runs = branchAndRuns[1]
+        for (const branchAndIDToRuns of branchToIDToRuns) {
+            const branch = branchAndIDToRuns[0]
+            const workflowIDToRuns = branchAndIDToRuns[1]
 
-            // Only one workflow run is good
-            if (runs.length == 1)
-                continue
+            for (const workflowIDAndRuns of workflowIDToRuns) {
+                const workflowID = workflowIDAndRuns[0]
+                const workflowRuns = workflowIDAndRuns[1]
 
-            // First run in array is the freshest one, keep it running
-            runs.shift()
+                // Only one workflow run is good
+                if (workflowRuns.length == 1)
+                    continue
 
-            core.info(`==> Branch: "${branch}"`)
+                // First run in array is the freshest one, keep it running
+                workflowRuns.shift()
 
-            for (const run of runs) {
-                core.info(`Cancelling workflow run: ${run.id}`)
+                for (const workflowRun of workflowRuns) {
+                    core.info(`Cancelling workflow run #${workflowRun.id} for "${branch}" branch`)
 
-                await client.actions.cancelWorkflowRun({
-                    ...github.context.repo,
-                    run_id: run.id
-                })
+                    await client.actions.cancelWorkflowRun({
+                        ...github.context.repo,
+                        run_id: workflowRun.id
+                    })
+                }
             }
         }
     } catch (error) {


### PR DESCRIPTION
Should be merged in sync with: https://github.com/Homebrew/homebrew-core/pull/62127

Note that this isn't really tested, I still don't know how to fake trigger duplicate CI workflow run so we can see this Action, well... in action.