### PR TITLE
setup-homebrew: handle add-path deprecation

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -54,7 +54,8 @@ fi
 
 HOMEBREW_CASK_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-cask"
 
-echo "::add-path::$HOMEBREW_PREFIX/bin"
+# Add brew to PATH
+echo "$HOMEBREW_PREFIX/bin" >> $GITHUB_PATH
 
 # Setup Homebrew/brew
 if [[ "$GITHUB_REPOSITORY" =~ ^.+/brew$ ]]; then


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Closes #101 