### PR TITLE
cancel-previous-runs: query workflow runs only for pr branch and pull_request event

### DIFF
--- a/cancel-previous-runs/main.js
+++ b/cancel-previous-runs/main.js
@@ -1,5 +1,6 @@
 const core = require('@actions/core')
 const github = require('@actions/github')
+const fs = require('fs')
 
 async function main() {
     try {
@@ -7,10 +8,16 @@ async function main() {
 
         const client = github.getOctokit(token)
 
+        // Parse event
+        const json = fs.readFileSync(process.env.GITHUB_EVENT_PATH, { encoding: "utf-8" })
+        const event = JSON.parse(json)
+        const pull = event.pull_request
+
         const repoWorkflowRuns = await client.actions.listWorkflowRunsForRepo({
             ...github.context.repo,
-            status: "in_progress", // OR queued (but we have some ghost workflow runs)
-            per_page: 50
+            branch: pull.head.ref,
+            event: "pull_request",
+            status: "in_progress OR queued"
         })
 
         // Map branch to workflow ID to workflow runs


### PR DESCRIPTION
We run this Action on pull_request_target event, no need to check workflow runs for e.g Homebrew:master branch.

I saw a situation where publishing jobs were cancelled because of it. This PR should solve the problem.