### PR TITLE
Allow alternative branch names to setup-homebrew

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -142,7 +142,10 @@ else
         ln -vs "$HOMEBREW_TAP_REPOSITORY" "$GITHUB_WORKSPACE"
         git_retry fetch origin "$GITHUB_SHA" '+refs/heads/*:refs/remotes/origin/*'
         git remote set-head origin --auto
-        git checkout --force -B master FETCH_HEAD
+
+        head="$(git -C "$DIR" symbolic-ref refs/remotes/origin/HEAD)"
+        head="${head#refs/remotes/origin/}"
+        git -C "$DIR" checkout --force -B "$head" origin/HEAD
         cd -
     fi
 


### PR DESCRIPTION
Allow `setup-homebrew` to be run on taps that don't use `master` as the main branch name.

GitHub has switched its default branch name to `main` so new taps that want to use the `setup-homebrew` action may use this as their main branch name. The action currently checks out the `master` branch by default, so this PR adds an optional setting for a different branch name (still defaults to `master`).

This is my first time diving into GitHub actions. What's the best way to test changes?