### PR TITLE
git-try-push: also retry pulls

### DIFF
--- a/git-try-push/main.js
+++ b/git-try-push/main.js
@@ -47,7 +47,14 @@ async function main() {
                 // and try again.
                 const delay = (i+1)**2
                 await exec.exec("sleep", [delay])
-                await exec.exec("git", ["pull", "--rebase", "--autostash", remote, branch])
+                // `git pull` can also fail, so do the same retry procedure here.
+                for (let j = 0; j < tries; j++) {
+                    try {
+                        await exec.exec("git", ["pull", "--rebase", "--autostash", remote, branch])
+                    } catch (error) {
+                        await exec.exec("sleep", [delay])
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
We're seeing a lot of issues on CI where bottles are getting correctly uploaded but the git info isn't getting merged into `master` due to transient git issues. This is because we're not doing retries of `git pull`s, just `git push`es. This pull request enables retry-and-backoff behavior on `git pull` as well.


https://github.com/Homebrew/homebrew-core/runs/1229540549?check_suite_focus=true
https://github.com/Homebrew/homebrew-core/runs/1228509044?check_suite_focus=true
https://github.com/Homebrew/homebrew-core/runs/1228508927?check_suite_focus=true
https://github.com/Homebrew/homebrew-core/runs/1228508997?check_suite_focus=true