### PR TITLE
setup-homebrew: fix branch detection

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -143,9 +143,9 @@ else
         git_retry fetch origin "$GITHUB_SHA" '+refs/heads/*:refs/remotes/origin/*'
         git remote set-head origin --auto
 
-        head="$(git -C "$DIR" symbolic-ref refs/remotes/origin/HEAD)"
+        head="$(git -C "$HOMEBREW_TAP_REPOSITORY" symbolic-ref refs/remotes/origin/HEAD)"
         head="${head#refs/remotes/origin/}"
-        git -C "$DIR" checkout --force -B "$head" origin/HEAD
+        git -C "$HOMEBREW_TAP_REPOSITORY" checkout --force -B "$head" origin/HEAD
         cd -
     fi
 


### PR DESCRIPTION
Follow up to #104

As pointed out in https://github.com/Homebrew/actions/pull/104#issuecomment-706309912, the PR adding branch detection fails for non-core taps because it tried to reference the `DIR` variable which is never set.

I believe `DIR` should be changed to `HOMEBREW_TAP_REPOSITORY`.

Again, I'm not really sure how to go about testing this change.

CC: @miccal