### PR TITLE
check-commit-format: label pull requests

### DIFF
--- a/.github/workflows/check-commit-format.yml
+++ b/.github/workflows/check-commit-format.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Test
         uses: ./check-commit-format/
         with:
-          failure_status: success
+          failure_label: enhancement

--- a/check-commit-format/action.yml
+++ b/check-commit-format/action.yml
@@ -9,10 +9,10 @@ inputs:
     description: GitHub token
     required: false
     default: ${{github.token}}
-  failure_status:
-    description: Status to set on failure. Can be any of failure, success, error, pending
+  failure_label:
+    description: Label to set on failure. Default is automerge-skip
     required: false
-    default: failure
+    default: automerge-skip
 runs:
   using: node12
   main: main.js


### PR DESCRIPTION
Label pull requests instead of setting a failure status.