### PR TITLE
README: add a bit more detail about local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ Particular workflow to test an Action is run only when this Action's directory c
 In addition to that, all test workflows will run if `package.json` or `package-lock.json` files or `node_modules` directory are changed.
 
 > Please be careful not to start multiple workflow jobs testing the same Action at once, as it may cause a failure, because of the way some Actions are tested.
+
+To test an action locally, first run `npm install` in the root of this repository, then in the directory of your action, run `node main.js`. Input variables are specified through the environment. For example, if an Action needed a `pull_request` input, running `export INPUT_PULL_REQUEST=1234` would pass that input to the Node.js script. For Actions that need variables from the [GitHub Events API](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/github-event-types), you'll need to save (or construct) the appropriate JSON file, then set `GITHUB_EVENT_PATH` to the file's location.


### PR DESCRIPTION
Updates the README and adds info on how to start testing events locally. I figured most of this out by reading the source code for `@actions/core`, so hopefully this saves someone some time.