### PR TITLE
setup-homebrew: add workaround to allow installation of fontconfig

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -169,4 +169,8 @@ fi
 if [[ "$RUNNER_OS" = "Linux" ]]; then
     sudo chown -R "$(whoami)" "$HOMEBREW_PREFIX"
     sudo chmod -R g-w,o-w /home/linuxbrew $HOME /opt
+
+    # Workaround: Remove fontconfig incompatible fonts provided by the poppler
+    # installation in GitHub Actions image
+    sudo rm -rf /usr/share/fonts/cmap
 fi


### PR DESCRIPTION
This PR adds a small workaround to the `setup-homebrew` action to resolve an incompatibility between the `fontconfig` formula and the poppler installation in the GitHub Actions ubuntu images.

The workaround removes poppler's font artefacts in the `/usr/share/fonts/cmap` folder because the containing files will cause `fc-cache -frv`, the command used to refresh the font cache after installing `fontconfig`, to fail.

This workaround currently seems like the best option since poppler can also be installed using Homebrew, so the expected usage of Homebrew's `fontconfig` and the preinstalled poppler version are unlikely. Furthermore, ensuring that `fontconfig` can be installed can be crucial for many formula, as it is found in many dependency trees, including any dependency on `openjdk`.

This PR follows a forum discussion that aimed to diagnose the problem: [link](https://discourse.brew.sh/t/problem-installing-fontconfig-on-ubuntu-latest-in-github-actions/9026/6)