### PR TITLE
Fix gh PR labelling issue

### DIFF
--- a/check-commit-format/main.js
+++ b/check-commit-format/main.js
@@ -80,7 +80,11 @@ async function main() {
         })
 
         // Get existing labels on PR
-        const existingLabels = pull.labels.map(label => label.name)
+        let existingLabels = await client.issues.listLabelsOnIssue({
+            ...github.context.repo,
+            issue_number: pull.number
+        })
+        existingLabels = existingLabels.data.map(label => label.name)
 
         // Copy labels into new Array
         const updatedLabels = existingLabels.slice()

--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -54,7 +54,11 @@ async function main() {
         }
 
         // Get existing labels on PR
-        const existingLabels = pull.labels.map(label => label.name)
+        let existingLabels = await client.issues.listLabelsOnIssue({
+            ...github.context.repo,
+            issue_number: pull.number
+        })
+        existingLabels = existingLabels.data.map(label => label.name)
 
         // Map constraint to an array of matching files objects
         const constraintToMatchingFiles = new Map()


### PR DESCRIPTION
I have noticed an issue with our labelling workflow when creating PRs using [`gh`](https://github.com/cli/cli). If I create a PR and add a label using `gh`, the label isn't passed to GitHub actions with the `pull_request` event. This means that our labelling and commit-checking workflows think there are no labels on the PR. These workflows will then apply the changes it deems necessary which includes removing the label that I just added. An example of where this happened is in https://github.com/Homebrew/homebrew-core/pull/65712.

I reported this issue in the `gh` repo at https://github.com/cli/cli/issues/2489. I received a response saying that they were aware of the issue and that it was due to a limitation in the GitHub API. They are currently unable to add the labels in the request as the PR creation, so the labels are actually added in a separate request. However, this means that the labels aren't passed to our workflow with the `pull_request` event. We, however, can retrieve the labels manually in the workflow instead of relying on them to be passed in the `pull_request` event.

Also, it turns out that this is part of the fix for #122!

---

I've demonstrated that this works as expected using a test tap that is set up with the same triage workflow that we use in homebrwe/core. Here are the results:

- https://github.com/Rylan12/homebrew-development/pull/10 is using the current `master` actions branch (i.e. the "bad" branch)
    - I created this PR using `gh` at the command line. I added the `enhancement` label during creation using `gh`.
    - This fails because the `enhancement` label added via the command-line during creation is removed by BrewTestBot
    - This failure demonstrates the issue
- https://github.com/Rylan12/homebrew-development/pull/11 and the following examples use the `get-labels-correctly` branch of my fork (i.e. the "good" branch)
    - I created this PR using `gh` at the command line. I added the `enhancement` label during creation using `gh`.
    - This succeeds because the `enhancement` label added via the command-line during creation is _not_ removed by BrewTestBot
    - This success demonstrates my solution solving the issue
- https://github.com/Rylan12/homebrew-development/pull/12
    -  I created this PR using `gh` at the command line. I did not add any labels during creation.
    - This succeeds because the correct labels were added and there were no failures.
    - This success demonstrates that my changes don't break existing functionality and work when there are no labels
- https://github.com/Rylan12/homebrew-development/pull/13
    - I created this PR using the GitHub web interface.  I added the `enhancement` label during creation using the web interface.
    - This succeeds because the `enhancement` label added via the command-line during creation is _not_ removed by BrewTestBot
    - This success demonstrates that my changes don't break existing functionality and work in non-`gh` situations.

---

Edit: CI is failing with a message saying `Error: Resource not accessible by integration`. Not sure what that means.