### PR TITLE
label-pull-requests: add keep_if_no_match option

### DIFF
--- a/label-pull-requests/README.md
+++ b/label-pull-requests/README.md
@@ -35,6 +35,11 @@ Will remove labels from a pull request that no longer apply.
               "label": "missing license",
               "missing_content": "license \"[^"]+\"",
               "path": "Formula/.+"
+          },
+          {
+              "label": "automerge-skip",
+              "path": "Formula/(patchelf|binutils).rb",
+              "keep_if_no_match": true
           }
       ]
 ```

--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -70,6 +70,12 @@ async function main() {
                     labelExists = true
                 }
 
+                // Continue if the label exists and we aren't going to remove
+                // it regardless of whether it applies or not
+                if (labelExists && constraint.keep_if_no_match) {
+                    continue
+                }
+
                 // Check constraints
                 constraintApplies = doesConstraintApply(constraint, file)
 


### PR DESCRIPTION
Resolves #122

This adds a configuration option to the `label-pull-requests` workflow that allows for certain conditions to be marked with the `keep_if_no_match` setting. When set, `label-pull-requests` will not attempt to remove the label if it already exists and no longer matches. This will be used in homebrew/core by the `automerge-skip` label. Currently, the configuration for that label is this:

```json
{
  "label": "automerge-skip",
  "path": "Formula/(patchelf|binutils).rb"
}
```

This meant that when `label-pull-requests` was run, the `automerge-skip` label was removed for all PRs that didn't modify either `Formula/patchelf.rb` or `Formula/binutils.rb`. After this PR, I'll change the configuration to:

```json
{
  "label": "automerge-skip",
  "path": "Formula/(patchelf|binutils).rb",
  "keep_if_no_match": true
}
```

Now, `automerge-skip` will still be added to PRs that modify `Formula/patchelf.rb` or `Formula/binutils.rb` but won't be removed from PRs that don't.
