### PR TITLE
Add remove-disabled-formulae action

### DIFF
--- a/remove-disabled-formulae/README.md
+++ b/remove-disabled-formulae/README.md
@@ -1,0 +1,10 @@
+# Remove Disabled Formulae Github Action
+
+An action that deletes formulae that have a disable date of more than one year ago.
+
+## Usage
+
+```yaml
+- name: Run brew script
+  uses: Homebrew/actions/remove-disabled-formulae@master
+```

--- a/remove-disabled-formulae/action.yml
+++ b/remove-disabled-formulae/action.yml
@@ -1,0 +1,20 @@
+name: Remove disabled formulae
+description: Delete formulae that have a disable date of more than one year ago
+author: Rylan12
+branding:
+  icon: trash-2
+  color: red
+outputs:
+  formulae-removed:
+    description: Whether any formulae were removed or not
+    value: ${{steps.remove-formulae.outputs.formulae-removed}}
+runs:
+  using: composite
+  steps:
+    - run: brew ruby "$GITHUB_ACTION_PATH/main.rb"
+      id: remove-formulae
+      shell: bash
+      env:
+        HOMEBREW_NO_ENV_FILTERING: 1
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_COLOR: 1

--- a/remove-disabled-formulae/main.rb
+++ b/remove-disabled-formulae/main.rb
@@ -1,0 +1,39 @@
+require 'formula'
+
+def git(*args)
+  system 'git', *args
+  exit $?.exitstatus unless $?.success?
+end
+
+puts 'Finding disabled formulae...'
+
+one_year_ago = Date.today << 12
+formulae_to_remove = Formula.to_a.select do |formula|
+  next false unless formula.disabled?
+  next false if formula.disable_date.nil?
+
+  formula.disable_date < one_year_ago
+end
+
+puts 'Removing old formulae...'
+
+formulae_to_remove.each { |formula| FileUtils.rm formula.path }
+
+tap_dir = Tap.fetch('homebrew/core').path
+
+out, err, status = Open3.capture3 'git', '-C', tap_dir.to_s, 'status', '--porcelain', '--ignore-submodules=dirty'
+raise err unless status.success?
+
+if out.chomp.empty?
+  puts 'No formulae removed.'
+  exit
+end
+
+git '-C', tap_dir.to_s, 'add', '--all'
+
+formulae_to_remove.each do |formula|
+  puts "Removed `#{formula.name}`."
+  git '-C', tap_dir.to_s, 'commit', formula.path.to_s, '--message', "#{formula.name}: remove formula", '--quiet'
+end
+
+puts '::set-output name=formulae-removed::true'


### PR DESCRIPTION
This PR adds a new action to detect outdated formulae and remove them.

See https://github.com/Homebrew/homebrew-core/pull/67386 and https://github.com/Homebrew/homebrew-core/issues/66360.
