### PR TITLE
label-pull-requests: fix keep_if_no_match option

### DIFF
--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -77,6 +77,7 @@ async function main() {
                 // Continue if the label exists and we aren't going to remove
                 // it regardless of whether it applies or not
                 if (labelExists && constraint.keep_if_no_match) {
+                    constraint.wanted = true
                     continue
                 }
 


### PR DESCRIPTION
(I accidentally committed to master (https://github.com/Homebrew/actions/commit/2eb1605eab6c3d2aca7193642312f08b93f04884), which I then reverted (https://github.com/Homebrew/actions/commit/e9569ab1c3faf2e33f7f44b0168e59811f33ee81); now I'm opening a proper PR)

`keep_if_no_match` appears not to be working: https://github.com/Homebrew/homebrew-core/pull/67757

`constraint.wanted` is used to determine if a label should be kept and is `false` by default. This PR adds a line that sets `constraint.wanted` to `true` if the label exists and `keep_if_no_match` is enabled