### PR TITLE
Revert "label-pull-requests: fix keep_if_no_match option (#134)"

### DIFF
--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -77,7 +77,6 @@ async function main() {
                 // Continue if the label exists and we aren't going to remove
                 // it regardless of whether it applies or not
                 if (labelExists && constraint.keep_if_no_match) {
-                    constraint.wanted = true
                     continue
                 }
 


### PR DESCRIPTION
PR #134 turned out not to have any effect, as the `automerge-skip` label is added and removed in the [`check-commit-format`](https://github.com/Homebrew/actions/blob/master/check-commit-format/main.js) action. ([`check-commit-format/action.yml`](https://github.com/Homebrew/actions/blob/master/check-commit-format/action.yml) defines `automerge-skip` as the default "failure label".)

This PR reverts #134, so that anyone reading the code does not become confused

Related:
- https://github.com/Homebrew/homebrew-core/pull/69992
- https://github.com/Homebrew/homebrew-core/pull/69994
- https://github.com/Homebrew/homebrew-core/pull/69996
- https://github.com/Homebrew/actions/pull/140