### PR TITLE
Call git_retry without sudo

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -33,12 +33,12 @@ if ! which brew &>/dev/null; then
     HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
     HOMEBREW_REPOSITORY="$HOMEBREW_PREFIX/Homebrew"
     sudo mkdir -p "$HOMEBREW_PREFIX"
-    sudo git_retry clone https://github.com/Homebrew/brew "$HOMEBREW_REPOSITORY"
+    git_retry clone https://github.com/Homebrew/brew "$HOMEBREW_REPOSITORY"
 
     HOMEBREW_CORE_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core"
     sudo mkdir -p "$HOMEBREW_CORE_REPOSITORY"
     sudo rm -rf "$HOMEBREW_CORE_REPOSITORY"
-    sudo git_retry clone https://github.com/Homebrew/linuxbrew-core "$HOMEBREW_CORE_REPOSITORY"
+    git_retry clone https://github.com/Homebrew/linuxbrew-core "$HOMEBREW_CORE_REPOSITORY"
 
     cd "$HOMEBREW_PREFIX"
     sudo mkdir -p bin etc include lib opt sbin share var/homebrew/linked Cellar


### PR DESCRIPTION
This PR fixes the setup-homebrew's main.sh script by calling `git_retry` function without `sudo`.
Functions cannot be called with `sudo`, since brew is pre-installed on runners, this code block must have never run before.