### PR TITLE
git-try-push: add origin_branch option

### DIFF
--- a/git-try-push/action.yml
+++ b/git-try-push/action.yml
@@ -24,7 +24,10 @@ inputs:
     required: false
     default: "20"
   force:
-    description: Whether to force-with-lease push or not
+    description: Whether to force-with-lease push (rebasing on origin_branch if needed)
+    required: false
+  origin_branch:
+    description: Branch to rebase on, defaults to branch
     required: false
 runs:
   using: node12

--- a/git-try-push/main.js
+++ b/git-try-push/main.js
@@ -9,6 +9,7 @@ async function main() {
         const branch = core.getInput("branch", { required: true })
         const tries = core.getInput("tries", { required: true })
         const force = core.getInput("force")
+        const origin_branch = core.getInput("origin_branch") || branch
 
         const git = "/usr/bin/git"
 
@@ -52,7 +53,7 @@ async function main() {
                 // `git pull` can also fail, so do the same retry procedure here.
                 for (let j = 0; j < tries; j++) {
                     try {
-                        await exec.exec(git, ["pull", "--rebase", "--autostash", remote, branch])
+                        await exec.exec(git, ["pull", "--rebase", "--autostash", remote, origin_branch])
                         break
                     } catch (error) {
                         await exec.exec("sleep", [delay])


### PR DESCRIPTION
See Homebrew/brew#10856 and [this comment](https://github.com/Homebrew/brew/pull/10854#issuecomment-799414425) for context. This PR adds the ability to `git push --force-with-lease` on the first try, using a separate flag.