### PR TITLE
Create action to setup commit signing

### DIFF
--- a/.github/workflows/setup-commit-signing.yml
+++ b/.github/workflows/setup-commit-signing.yml
@@ -1,0 +1,49 @@
+name: Setup GPG commit signing
+
+on:
+  push:
+    paths:
+      - '**setup-commit-signing**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'node_modules/**'
+
+jobs:
+  commit-signing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+
+      - name: Configure git user
+        uses: ./git-user-config/
+        with:
+          username: BrewTestBot
+
+      - name: Set up commit signing
+        id: set-up-commit-signing
+        uses: ./setup-commit-signing/
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
+      - name: Make changes and commit them
+        run: |
+          git checkout -b test-setup-commit-signing
+
+          touch test.txt
+          echo "Hello, Homebrew!" >> test.txt
+
+          git add test.txt
+          git commit -m "test.txt: create and add content."
+        env:
+          GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+
+      - name: Test
+        run: |
+          git log --show-signature -1 | grep "gpg: Good"
+
+      - name: Push commits
+        uses: ./git-try-push/
+        with:
+          token: ${{ github.token }}
+          branch: test-setup-commit-signing

--- a/setup-commit-signing/README.md
+++ b/setup-commit-signing/README.md
@@ -1,0 +1,24 @@
+# Setup GPG Commit Signing GitHub Action
+
+An action that sets up GPG commit signing.
+
+## Usage
+
+```yaml
+- name: Set up GPG commit signing
+  id: set-up-commit-signing
+  uses: Homebrew/actions/setup-commit-signing@master
+  with:
+    signing_key: ${{ secrets.GPG_SIGNING_KEY }}
+```
+
+When committing changes, ensure that the value of the environment variable `GPG_PASSPHRASE` is set to the signing key's passphrase.
+
+```yaml
+- name: Add and commit changes
+  run: |
+    git add file.txt
+    git commit -m "Updated file.txt"
+  env:
+    GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+```

--- a/setup-commit-signing/action.yml
+++ b/setup-commit-signing/action.yml
@@ -1,0 +1,17 @@
+name: setup-commit-signing
+description: Set up GPG commit signing
+author: nandahkrishna
+branding:
+  icon: user-check
+  color: green
+inputs:
+  signing_key:
+    description: Secret key to use for signing commits
+    required: true
+runs:
+  using: composite
+  steps:
+    - run: |
+        "$GITHUB_ACTION_PATH/main.sh" '${{ inputs.signing_key }}'
+      shell: bash
+      id: setup

--- a/setup-commit-signing/main.sh
+++ b/setup-commit-signing/main.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+GPG_SIGNING_KEY="${1}"
+
+export GNUPGHOME="$HOME/.gnupg/"
+mkdir -p "$GNUPGHOME"
+chmod 0700 "$GNUPGHOME"
+
+GPG_EXEC=$(command -v gpg)
+
+# Wrapper script to use passphrase non-interactively with git
+GPG_WITH_PASSPHRASE=$(mktemp)
+echo "$GPG_EXEC"' --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --batch --no-tty "$@"' > $GPG_WITH_PASSPHRASE
+chmod +x $GPG_WITH_PASSPHRASE
+git config --global gpg.program $GPG_WITH_PASSPHRASE
+
+echo "$GPG_SIGNING_KEY" | base64 --decode --ignore-garbage | gpg --batch --no-tty --quiet --yes --import
+GPG_KEY_ID=$(gpg --list-keys --with-colons | sed -ne "/^sub:/ p;" | cut -d: -f5)
+
+git config --global user.signingkey $GPG_KEY_ID
+git config --global commit.gpgsign true


### PR DESCRIPTION
This PR creates a new action to setup commit signing, to be used mainly with BrewTestBot. I thought creating a separate action would be useful in debugging issues with commit signing, and thus better than adding this to `git-user-config`.

Note: The test workflow I've added will not work unless the necessary secrets (`BREWTESTBOT_GPG_SIGNING_SUBKEY` and `BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE`) are accessible in this repository (cc @MikeMcQuaid).

Also, I was wondering if pushing a test signed commit to a branch to ensure that the "Verified" badge appears would be okay. Checking the output of `git log --show-signature -1` is not sufficient to ensure this (I noticed some issues when I was testing this functionality earlier).