### PR TITLE
setup-homebrew: allow to run as normal user in container

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -43,7 +43,7 @@ HOMEBREW_CASK_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-ca
 # Do in container or on the runner
 if grep -q actions_job /proc/1/cgroup; then
     # Fix permissions to give normal user access
-    sudo chown -R "$(whoami)" "$HOME" "$GITHUB_WORKSPACE/.."
+    sudo chown -R "$(whoami)" "$HOME" "$PWD/.."
 else
     # Add brew to PATH
     echo "$HOMEBREW_PREFIX/bin" >> $GITHUB_PATH

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -40,8 +40,14 @@ HOMEBREW_REPOSITORY="$(brew --repo)"
 HOMEBREW_CORE_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core"
 HOMEBREW_CASK_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-cask"
 
-# Add brew to PATH
-echo "$HOMEBREW_PREFIX/bin" >> $GITHUB_PATH
+# Do in container or on the runner
+if grep -q actions_job /proc/1/cgroup; then
+    # Fix permissions to give normal user access
+    sudo chown -R "$(whoami)" "$HOME" "$GITHUB_WORKSPACE/.."
+else
+    # Add brew to PATH
+    echo "$HOMEBREW_PREFIX/bin" >> $GITHUB_PATH
+fi
 
 # Setup Homebrew/brew
 if [[ "$GITHUB_REPOSITORY" =~ ^.+/brew$ ]]; then


### PR DESCRIPTION
By modifying permissions of some directories in Docker container we are able to run `brew` as `linuxbrew` user inside it without any friction (at least looking at `coreutils` testing PR).