### PR TITLE
setup-commit-signing: don't use `--ignore-garbage` with `base64`

### DIFF
--- a/.github/workflows/setup-commit-signing.yml
+++ b/.github/workflows/setup-commit-signing.yml
@@ -7,6 +7,8 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'node_modules/**'
+    branches-ignore:
+      - master
 
 jobs:
   commit-signing:

--- a/setup-commit-signing/main.sh
+++ b/setup-commit-signing/main.sh
@@ -16,7 +16,7 @@ echo "$GPG_EXEC"' --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --batc
 chmod +x $GPG_WITH_PASSPHRASE
 git config --global gpg.program $GPG_WITH_PASSPHRASE
 
-echo "$GPG_SIGNING_KEY" | base64 --decode --ignore-garbage | gpg --batch --no-tty --quiet --yes --import
+echo "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --no-tty --quiet --yes --import
 GPG_KEY_ID=$(gpg --list-keys --with-colons | sed -ne "/^sub:/ p;" | cut -d: -f5)
 
 git config --global user.signingkey $GPG_KEY_ID


### PR DESCRIPTION
This PR removes the `--ignore-garbage` option which isn't available with `base64` on macOS runners. The workflow seems to work without using this option.