### PR TITLE
setup-commit-signing: use HOMEBREW_GPG_PASSPHRASE

### DIFF
--- a/.github/workflows/setup-commit-signing.yml
+++ b/.github/workflows/setup-commit-signing.yml
@@ -38,7 +38,7 @@ jobs:
           git add test.txt
           git commit -m "test.txt: create and add content."
         env:
-          GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Test
         run: |

--- a/setup-commit-signing/README.md
+++ b/setup-commit-signing/README.md
@@ -12,7 +12,7 @@ An action that sets up GPG commit signing.
     signing_key: ${{ secrets.GPG_SIGNING_KEY }}
 ```
 
-When committing changes, ensure that the value of the environment variable `GPG_PASSPHRASE` is set to the signing key's passphrase.
+When committing changes, ensure that the value of the environment variable `HOMEBREW_GPG_PASSPHRASE` is set to the signing key's passphrase.
 
 ```yaml
 - name: Add and commit changes
@@ -20,5 +20,5 @@ When committing changes, ensure that the value of the environment variable `GPG_
     git add file.txt
     git commit -m "Updated file.txt"
   env:
-    GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+    HOMEBREW_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 ```

--- a/setup-commit-signing/main.sh
+++ b/setup-commit-signing/main.sh
@@ -12,7 +12,7 @@ GPG_EXEC=$(command -v gpg)
 
 # Wrapper script to use passphrase non-interactively with git
 GPG_WITH_PASSPHRASE=$(mktemp)
-echo "$GPG_EXEC"' --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --batch --no-tty "$@"' > $GPG_WITH_PASSPHRASE
+echo "$GPG_EXEC"' --pinentry-mode loopback --passphrase "$HOMEBREW_GPG_PASSPHRASE" --batch --no-tty "$@"' > $GPG_WITH_PASSPHRASE
 chmod +x $GPG_WITH_PASSPHRASE
 git config --global gpg.program $GPG_WITH_PASSPHRASE
 


### PR DESCRIPTION
This fix is needed to prevent the GPG passphrase from being filtered out of the environment, causing `system "git", "commit" ...` to fail.