### PR TITLE
label-pull-requests: add `pr_body_content` field

### DIFF
--- a/label-pull-requests/README.md
+++ b/label-pull-requests/README.md
@@ -40,6 +40,10 @@ Will remove labels from a pull request that no longer apply.
               "label": "automerge-skip",
               "path": "Formula/(patchelf|binutils).rb",
               "keep_if_no_match": true
+          },
+          {
+              "label": "bump-formula-pr",
+              "pr_body_content": "Created with `brew bump-formula-pr`"
           }
       ]
 ```

--- a/label-pull-requests/action.yml
+++ b/label-pull-requests/action.yml
@@ -20,6 +20,7 @@ inputs:
         - "except" (optional): File path(s) to exclude
         - "content" (optional): Changed file content, regex matching
         - "missing_content" (optional): Missing file content, regex matching
+        - "pr_body_content" (optional): Regex to check against the PR body
 
       Example:
         [
@@ -40,6 +41,9 @@ inputs:
           }, {
             "label": "missing license",
             "missing_content": "license \"[^"]+\""
+          }, {
+            "label": "bump-formula-pr",
+            "pr_body_content": "Created with `brew bump-formula-pr`"
           }
         ]
     required: true


### PR DESCRIPTION
Adds a `pr_body_content` field that allows for a label to be applied using a regex match of the PR body.

This allows for https://github.com/Homebrew/homebrew-core/issues/76763 to be done.

I've tested this locally and it seems to work as expected. You can see the labels being automatically added and removed in https://github.com/Homebrew/homebrew-core/pull/76886
