### PR TITLE
wait-for-idle-runner: remove id

### DIFF
--- a/wait-for-idle-runner/action.yml
+++ b/wait-for-idle-runner/action.yml
@@ -23,4 +23,3 @@ outputs:
 runs:
   using: node12
   main: main.js
-  id: killable


### PR DESCRIPTION
This needs to be set in the workflow that uses this action.
Fixes:
Homebrew/actions/master/wait-for-idle-runner/action.yml (Line: 26, Col: 3): Unexpected value 'id'