### PR TITLE
wait-for-idle-runner: repository_name is not required as there is a d…

### DIFF
--- a/wait-for-idle-runner/action.yml
+++ b/wait-for-idle-runner/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: true
   repository_name:
     description: Full name of the repository
-    required: true
+    required: false
     default: ${{github.repository}}
 outputs:
   runner-found:


### PR DESCRIPTION
…efault value