### PR TITLE
`label-pull-requests`: handle `null` PR body

### DIFF
--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -147,7 +147,11 @@ async function main() {
                 labelExists = true
             }
 
-            constraintApplies = body.match(constraint.pr_body_content)
+            if (body != null) {
+            	constraintApplies = body.match(constraint.pr_body_content)
+	    } else {
+		constraintApplies = true
+	    }
 
             if (labelExists && constraintApplies) {
                 continue


### PR DESCRIPTION
The triage workflow initially failed in Homebrew/homebrew-core#79146 because the PR body was empty. This PR aims to handle that case by setting `constraintApplies = true` if `body` is `null`.