### PR TITLE
setup-homebrew: check for another string in container too

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -41,7 +41,7 @@ HOMEBREW_CORE_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-co
 HOMEBREW_CASK_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-cask"
 
 # Do in container or on the runner
-if grep -q actions_job /proc/1/cgroup; then
+if [[ -f /proc/1/cgroup ]] && grep -qE "actions_job|docker" /proc/1/cgroup; then
     # Fix permissions to give normal user access
     sudo chown -R "$(whoami)" "$HOME" "$PWD/.."
 else


### PR DESCRIPTION
Look for another string, because the one already present... could not be present on self-hosted runners it turns out.