### PR TITLE
cancel-previous-runs: deprecated.

### DIFF
--- a/cancel-previous-runs/README.md
+++ b/cancel-previous-runs/README.md
@@ -1,12 +1,5 @@
-# Cancel previous runs Github Action
+# Cancel previous runs Github Action (deprecated)
 
-An action that cancels all previous uncompleted duplicated workflow runs for a branch.
+Was an action that cancels all previous uncompleted duplicated workflow runs for a branch.
 
-## Usage
-
-```yaml
-- name: Cancel previous runs
-  uses: Homebrew/actions/cancel-previous-runs@master
-  with:
-    token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
-```
+Replaced with [GitHub Actions native `concurrency`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency).


### PR DESCRIPTION
Replace with native GitHub Actions version.