### PR TITLE
setup.sh: remove set -xeo pipefail

### DIFF
--- a/create-gcloud-instance/setup.sh
+++ b/create-gcloud-instance/setup.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -xeo pipefail
 
 RUNNER_NAME=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/RUNNER_NAME -H "Metadata-Flavor: Google")
 VM_TOKEN=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/VM_TOKEN -H "Metadata-Flavor: Google")


### PR DESCRIPTION
This breaks the setup in ubuntu 20.04, as the install script uses
fail checks to install the right libicu version, see:
https://github.com/fhammerl/runner/blob/53e76e0257007b065e6569a3b6ae82801d4b8c2f/src/Misc/layoutbin/installdependencies.sh#L77-L95

Our setup got broken by https://github.com/actions/runner/pull/1228.
The error message we had is:

Aug 10 17:15:43 linux-self-hosted-1 GCEMetadataScripts[1355]: 2021/08/10 17:15:43 GCEMetadataScripts: startup-script: ++ apt_get_with_fallbacks libicu72 libicu71 libicu70 libicu69 libicu68 libicu67 libicu66 libicu65 libicu63 libicu60 libicu57 libicu55 libicu52
Aug 10 17:15:43 linux-self-hosted-1 GCEMetadataScripts[1355]: 2021/08/10 17:15:43 GCEMetadataScripts: startup-script: ++ apt-get install -y libicu72
Aug 10 17:15:43 linux-self-hosted-1 GCEMetadataScripts[1355]: 2021/08/10 17:15:43 GCEMetadataScripts: startup-script: Reading package lists...
Aug 10 17:15:43 linux-self-hosted-1 GCEMetadataScripts[1355]: 2021/08/10 17:15:43 GCEMetadataScripts: startup-script: Building dependency tree...
Aug 10 17:15:43 linux-self-hosted-1 GCEMetadataScripts[1355]: 2021/08/10 17:15:43 GCEMetadataScripts: startup-script: Reading state information...
Aug 10 17:15:44 linux-self-hosted-1 GCEMetadataScripts[1355]: 2021/08/10 17:15:44 GCEMetadataScripts: startup-script: E: Unable to locate package libicu72