### PR TITLE
workflows/vendor-node-modules: use HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN

### DIFF
--- a/.github/workflows/vendor-node-modules.yml
+++ b/.github/workflows/vendor-node-modules.yml
@@ -50,5 +50,6 @@ jobs:
       - name: Push to pull request
         uses: ./git-try-push/
         with:
+          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           branch: ${{ steps.checkout.outputs.branch }}
           force: true


### PR DESCRIPTION
This is needed to trigger CI.