### PR TITLE
create-gcloud-instance: rename RUNNER_NAME env

### DIFF
--- a/create-gcloud-instance/action.yaml
+++ b/create-gcloud-instance/action.yaml
@@ -35,7 +35,7 @@ runs:
     - run: "$GITHUB_ACTION_PATH/create-gcloud-instance.sh"
       shell: bash
       env:
-        RUNNER_NAME: ${{ inputs.runner_name }}
+        GCP_RUNNER_NAME: ${{ inputs.runner_name }}
         GCP_PROJECT_ID: ${{ inputs.gcp_project_id }}
         GCP_SERVICE_ACCOUNT: ${{ inputs.gcp_service_account }}
         GCP_SA_KEY: ${{ inputs.gcp_sa_key }}

--- a/create-gcloud-instance/create-gcloud-instance.sh
+++ b/create-gcloud-instance/create-gcloud-instance.sh
@@ -13,19 +13,19 @@ GCLOUD_DISK_SIZE="30GB"
 STARTUP_SCRIPT="${GITHUB_ACTION_PATH}/setup.sh"
 
 # shellcheck disable=SC2154
-echo ">> checking for already existing ${RUNNER_NAME} instance"
-runner=$(gcloud compute instances list --format="value(name)" --filter="${RUNNER_NAME}" | head -n 1)
+echo ">> checking for already existing ${GCP_RUNNER_NAME} instance"
+runner=$(gcloud compute instances list --format="value(name)" --filter="${GCP_RUNNER_NAME}" | head -n 1)
 if [[ -n "${runner}" ]]
 then
      echo ">> deleting old ${runner} instance"
      echo ">> this might take some time ..."
      # shellcheck disable=SC2154
-     gcloud compute --project="${GCP_PROJECT_ID}" instances delete "${RUNNER_NAME}" --zone="${GCLOUD_ZONE}" --quiet
+     gcloud compute --project="${GCP_PROJECT_ID}" instances delete "${GCP_RUNNER_NAME}" --zone="${GCLOUD_ZONE}" --quiet
 fi
 
 echo ">> create new instance"
 # shellcheck disable=SC2154
-gcloud compute --project="${GCP_PROJECT_ID}" instances create "${RUNNER_NAME}" \
+gcloud compute --project="${GCP_PROJECT_ID}" instances create "${GCP_RUNNER_NAME}" \
                --zone="${GCLOUD_ZONE}" \
                --machine-type="${GCLOUD_MACHINE}" \
                --subnet=default  \
@@ -37,10 +37,10 @@ gcloud compute --project="${GCP_PROJECT_ID}" instances create "${RUNNER_NAME}" \
                --image-project=ubuntu-os-cloud \
                --boot-disk-size="${GCLOUD_DISK_SIZE}" \
                --boot-disk-type=pd-ssd \
-               --boot-disk-device-name="${RUNNER_NAME}" \
+               --boot-disk-device-name="${GCP_RUNNER_NAME}" \
                --no-shielded-secure-boot \
                --shielded-vtpm \
                --shielded-integrity-monitoring \
                --reservation-affinity=any \
                --metadata-from-file startup-script="${STARTUP_SCRIPT}" \
-               --metadata RUNNER_NAME="${RUNNER_NAME}",VM_TOKEN="${VM_TOKEN}",REPOSITORY_NAME="${REPOSITORY_NAME}",GITHUB_TOKEN="${GITHUB_TOKEN}"
+               --metadata RUNNER_NAME="${GCP_RUNNER_NAME}",VM_TOKEN="${VM_TOKEN}",REPOSITORY_NAME="${REPOSITORY_NAME}",GITHUB_TOKEN="${GITHUB_TOKEN}"


### PR DESCRIPTION
GitHub Actions now has its own `RUNNER_NAME` env. As a result we can no longer call our env by that name as it gets overridden, breaking the script.