### PR TITLE
setup-homebrew: don't chmod /opt

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -171,7 +171,7 @@ fi
 # Setup Linux permissions
 if [[ "$RUNNER_OS" = "Linux" ]]; then
     sudo chown -R "$(whoami)" "$HOMEBREW_PREFIX"
-    sudo chmod -R g-w,o-w /home/linuxbrew $HOME /opt
+    sudo chmod -R g-w,o-w /home/linuxbrew $HOME
 
     # Workaround: Remove fontconfig incompatible fonts provided by the poppler
     # installation in GitHub Actions image


### PR DESCRIPTION
It is very slow. If this ends up breaking something we should try think of an alternative.