### PR TITLE
setup-homebrew: apply self-hosted logic to Linux

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -50,11 +50,16 @@ else
     echo "$HOMEBREW_PREFIX/bin" >> $GITHUB_PATH
 fi
 
+# TODO: remove me after a few days
+if [[ -n "${GITHUB_ACTIONS_HOMEBREW_MACOS_SELF_HOSTED-}" ]]; then
+    GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=1
+fi
+
 # Setup Homebrew/brew
 if [[ "$GITHUB_REPOSITORY" =~ ^.+/brew$ ]]; then
     cd "$HOMEBREW_REPOSITORY"
     rm -rf "$GITHUB_WORKSPACE"
-    if [[ -n "${GITHUB_ACTIONS_HOMEBREW_MACOS_SELF_HOSTED-}" ]]; then
+    if [[ -n "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-}" ]]; then
         mkdir -vp "$GITHUB_WORKSPACE"
     else
         ln -vs "$HOMEBREW_REPOSITORY" "$GITHUB_WORKSPACE"
@@ -80,7 +85,7 @@ echo "::set-output name=gems-hash::$GEMS_HASH"
 if [[ "$GITHUB_REPOSITORY" =~ ^.+/(home|linux)brew-core$ ]]; then
     cd "$HOMEBREW_CORE_REPOSITORY"
     rm -rf "$GITHUB_WORKSPACE"
-    if [[ -n "${GITHUB_ACTIONS_HOMEBREW_MACOS_SELF_HOSTED-}" ]]; then
+    if [[ -n "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-}" ]]; then
         mkdir -vp "$GITHUB_WORKSPACE"
     else
         ln -vs "$HOMEBREW_CORE_REPOSITORY" "$GITHUB_WORKSPACE"
@@ -93,8 +98,8 @@ if [[ "$GITHUB_REPOSITORY" =~ ^.+/(home|linux)brew-core$ ]]; then
 # Setup all other taps
 else
     if [[ "$GITHUB_REPOSITORY" =~ ^.+/homebrew-.+$ ]]; then
-        if [[ -n "${GITHUB_ACTIONS_HOMEBREW_MACOS_SELF_HOSTED-}" ]]; then
-            echo "macOS self-hosted runners not supported for this tap!"
+        if [[ -n "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-}" ]]; then
+            echo "Homebrew self-hosted runners not supported for this tap!"
             exit 1
         fi
 


### PR DESCRIPTION
(Re-)introduce `GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED` as we need to apply the self-hosted logic to Linux too.