### PR TITLE
create-gcloud-instance: set Homebrew self-hosted env

### DIFF
--- a/create-gcloud-instance/config_runner.sh
+++ b/create-gcloud-instance/config_runner.sh
@@ -3,6 +3,8 @@ set -eo pipefail
 
 cd /home/actions/actions-runner || exit
 
+echo 'GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=1' >> .env
+
 # shellcheck disable=SC2154
 # SC2154: REPOSITORY_NAME/VM_TOKEN/RUNNER_NAME is referenced but not assigned:
 # These variables are set from the script environment.


### PR DESCRIPTION
Instead of setting it in workflows.

If this works, I will do the same for macOS in the next maintenance window (later this week probably).