### PR TITLE
Revert "bump-formulae: use `brew bump`."

### DIFF
--- a/bump-formulae/action.yml
+++ b/bump-formulae/action.yml
@@ -14,8 +14,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: brew bump ${{inputs.formulae}}
+    - run: brew ruby $GITHUB_ACTION_PATH/main.rb
       shell: sh
       env:
         HOMEBREW_DEVELOPER: "1"
         HOMEBREW_GITHUB_API_TOKEN: ${{inputs.token}}
+        HOMEBREW_BUMP_FORMULAE: ${{inputs.formulae}}

--- a/bump-formulae/main.rb
+++ b/bump-formulae/main.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'formula'
+require 'utils/pypi'
+
+module Homebrew
+  module_function
+
+  def print_command(*cmd)
+    puts "[command]#{cmd.join(' ').gsub("\n", ' ')}"
+  end
+
+  def brew(*args)
+    print_command ENV["HOMEBREW_BREW_FILE"], *args
+    safe_system ENV["HOMEBREW_BREW_FILE"], *args
+  end
+
+  def read_brew(*args)
+    print_command ENV["HOMEBREW_BREW_FILE"], *args
+    output = `#{ENV["HOMEBREW_BREW_FILE"]} #{args.join(' ')}`.chomp
+    odie output if $CHILD_STATUS.exitstatus != 0
+    output
+  end
+
+  # Get formulae
+  formulae = ENV['HOMEBREW_BUMP_FORMULAE']
+  formulae = formulae.split(/[ ,\n]/).reject(&:blank?)
+
+  # Define additional message
+  message = 'Automated bump.'
+
+  # Get livecheck info
+  json = read_brew 'livecheck',
+                    '--formula',
+                    '--quiet',
+                    '--newer-only',
+                    '--json',
+                    *formulae
+  json = JSON.parse json
+
+  # Define error
+  err = nil
+
+  # Loop over livecheck info
+  json.each do |info|
+    # Skip if there is no version field
+    next unless info['version']
+
+    # Get info about formula
+    formula = info['formula']
+    version = info['version']['latest']
+
+    # Get stable software spec of the formula
+    stable = Formula[formula].stable
+
+    # Check if formula is originating from PyPi
+    if PyPI.update_pypi_url(stable.url, version)
+      # Install pipgrip utility so resources from PyPi get updated too
+      brew 'install', 'pipgrip' unless Formula["pipgrip"].any_version_installed?
+    end
+
+    begin
+      # Finally bump the formula
+      brew 'bump-formula-pr',
+            '--no-browse',
+            "--message=#{message}",
+            "--version=#{version}",
+            formula
+    rescue ErrorDuringExecution => e
+      # Continue execution on error, but save the exeception
+      err = e
+    end
+  end
+
+  # Die if any error occured
+  odie err if err
+end


### PR DESCRIPTION
This reverts commit 0925dba197462055da7c1fac4cfafa9cb97b9139.

- The `main.rb` is doing more than just livecheck, but also bump the PRs as well (which caused some failed runs like [this](https://github.com/Homebrew/homebrew-core/runs/4989400182))
- We can do another PR of replacing the `livecheck` cmd usage in the `main.rb` script

cc @MikeMcQuaid @dawidd6 