### PR TITLE
setup-commit-signing: handle GPG versions < 2.1

### DIFF
--- a/.github/workflows/setup-commit-signing.yml
+++ b/.github/workflows/setup-commit-signing.yml
@@ -12,7 +12,14 @@ on:
 
 jobs:
   commit-signing:
+    strategy:
+      matrix:
+        container:
+          - ''
+          - image: ghcr.io/homebrew/ubuntu16.04:master
+            options: --user=root
     runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
     steps:
       - name: Checkout
         uses: actions/checkout@main

--- a/setup-commit-signing/main.sh
+++ b/setup-commit-signing/main.sh
@@ -9,10 +9,23 @@ mkdir -p "$GNUPGHOME"
 chmod 0700 "$GNUPGHOME"
 
 GPG_EXEC=$(command -v gpg)
+if [ -z "$GPG_EXEC" ]; then
+  echo "GPG not found." >&2
+  exit 1
+fi
+
+GPG_VERSION=$(gpg --version | head -n1 | cut -d' ' -f3)
+GPG_MAJOR=$(echo $GPG_VERSION | cut -d. -f1)
+GPG_MINOR=$(echo $GPG_VERSION | cut -d. -f2)
+if (( GPG_MAJOR > 2 || (GPG_MAJOR == 2 && GPG_MINOR >= 1) )); then
+  PINENTRY_MODE="--pinentry-mode loopback"
+else
+  PINENTRY_MODE=""
+fi
 
 # Wrapper script to use passphrase non-interactively with git
 GPG_WITH_PASSPHRASE=$(mktemp)
-echo "$GPG_EXEC"' --pinentry-mode loopback --passphrase "$HOMEBREW_GPG_PASSPHRASE" --batch --no-tty "$@"' > $GPG_WITH_PASSPHRASE
+echo "$GPG_EXEC"' '"$PINENTRY_MODE"' --passphrase "$HOMEBREW_GPG_PASSPHRASE" --batch --no-tty "$@"' > $GPG_WITH_PASSPHRASE
 chmod +x $GPG_WITH_PASSPHRASE
 git config --global gpg.program $GPG_WITH_PASSPHRASE
 


### PR DESCRIPTION
This is useful when running in a Homebrew docker container, which won't have gnupg installed by default.