### PR TITLE
setup-commit-signing: allow prespecified GNUPGHOME

### DIFF
--- a/setup-commit-signing/main.sh
+++ b/setup-commit-signing/main.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 
 GPG_SIGNING_KEY="${1}"
 
-export GNUPGHOME="$HOME/.gnupg/"
+if [ -z "${GNUPGHOME:-}" ]; then
+  export GNUPGHOME="$HOME/.gnupg/"
+fi
 mkdir -p "$GNUPGHOME"
 chmod 0700 "$GNUPGHOME"
 


### PR DESCRIPTION
The home directory is for some reason not correctly cleared on self-hosted runners (this'll eventually be fixed by ephemeral). For security reasons, allow `GNUPGHOME` to be overridden.