### PR TITLE
setup-commit-signing: set GNUPGHOME in wrapper script

### DIFF
--- a/setup-commit-signing/main.sh
+++ b/setup-commit-signing/main.sh
@@ -27,7 +27,7 @@ fi
 
 # Wrapper script to use passphrase non-interactively with git
 GPG_WITH_PASSPHRASE=$(mktemp)
-echo "$GPG_EXEC"' '"$PINENTRY_MODE"' --passphrase "$HOMEBREW_GPG_PASSPHRASE" --batch --no-tty "$@"' > $GPG_WITH_PASSPHRASE
+echo 'GNUPGHOME="'"$GNUPGHOME"'" '"$GPG_EXEC"' '"$PINENTRY_MODE"' --passphrase "$HOMEBREW_GPG_PASSPHRASE" --batch --no-tty "$@"' > $GPG_WITH_PASSPHRASE
 chmod +x $GPG_WITH_PASSPHRASE
 git config --global gpg.program $GPG_WITH_PASSPHRASE
 


### PR DESCRIPTION
brew env filters `GNUPGHOME`, so make sure it is set within the wrapper script instead of relying on the default.