### PR TITLE
runtime: upgrade to use nodejs v16

### DIFF
--- a/cancel-previous-runs/action.yml
+++ b/cancel-previous-runs/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: false
     default: ${{github.token}}
 runs:
-  using: node12
+  using: node16
   main: main.js

--- a/check-commit-format/action.yml
+++ b/check-commit-format/action.yml
@@ -14,5 +14,5 @@ inputs:
     required: false
     default: automerge-skip
 runs:
-  using: node12
+  using: node16
   main: main.js

--- a/dismiss-approvals/action.yml
+++ b/dismiss-approvals/action.yml
@@ -16,5 +16,5 @@ inputs:
     description: Dismissal message
     required: true
 runs:
-  using: node12
+  using: node16
   main: main.js

--- a/download-artifact/action.yml
+++ b/download-artifact/action.yml
@@ -30,5 +30,5 @@ inputs:
     required: false
     default: "./"
 runs:
-  using: node12
+  using: node16
   main: main.js

--- a/git-try-push/action.yml
+++ b/git-try-push/action.yml
@@ -30,5 +30,5 @@ inputs:
     description: Branch to rebase on, defaults to branch
     required: false
 runs:
-  using: node12
+  using: node16
   main: main.js

--- a/git-user-config/action.yml
+++ b/git-user-config/action.yml
@@ -19,5 +19,5 @@ outputs:
   email:
     description: Configured git user's email
 runs:
-  using: node12
+  using: node16
   main: main.js

--- a/label-pull-requests/action.yml
+++ b/label-pull-requests/action.yml
@@ -77,5 +77,5 @@ inputs:
 
     required: true
 runs:
-  using: node12
+  using: node16
   main: main.js

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -12,9 +12,9 @@
       }
     },
     "node_modules/@actions/exec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
-      "integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
       "dependencies": {
         "@actions/io": "^1.0.1"
       }
@@ -168,9 +168,9 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "node_modules/filesize": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.6.tgz",
-      "integrity": "sha512-sHvRqTiwdmcuzqet7iVwsbwF6UrV3wIgDf2SHNdY1Hgl8PC45HZg/0xtdw6U2izIV4lccnrY9ftl6wZFNdjYMg==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
+      "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -195,11 +195,22 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/once": {
@@ -209,6 +220,11 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -222,6 +238,20 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/post-comment/action.yml
+++ b/post-comment/action.yml
@@ -22,5 +22,5 @@ inputs:
     description: Bot's username
     required: false
 runs:
-  using: node12
+  using: node16
   main: main.js

--- a/post-review/action.yml
+++ b/post-review/action.yml
@@ -20,5 +20,5 @@ inputs:
     description: Review content
     required: false
 runs:
-  using: node12
+  using: node16
   main: main.js

--- a/wait-for-idle-runner/action.yml
+++ b/wait-for-idle-runner/action.yml
@@ -21,5 +21,5 @@ outputs:
   runner-idle:
     description: Runner is idle (true/false)
 runs:
-  using: node12
+  using: node16
   main: main.js


### PR DESCRIPTION
This is consistent with all the recent github action updates. (mostly in `actions` repos, like `actions/checkout`, `actions/setup-node`, etc.)