### PR TITLE
Replace deprecated `Formula.to_a`

### DIFF
--- a/remove-disabled-formulae/main.rb
+++ b/remove-disabled-formulae/main.rb
@@ -8,7 +8,7 @@ end
 puts 'Finding disabled formulae...'
 
 one_year_ago = Date.today << 12
-formulae_to_remove = Formula.to_a.select do |formula|
+formulae_to_remove = Formula.all.select do |formula|
   next false unless formula.disabled?
   next false if formula.disable_date.nil?
 


### PR DESCRIPTION
Remove disabled formulae runs [have not been succeeding](https://github.com/Homebrew/homebrew-core/runs/6741661030?check_suite_focus=true#step:5:23) because `Formula::to_a` is no longer allowed (as of https://github.com/Homebrew/brew/pull/13347). This PR replaces `Formula::to_a` with `Formula::all` to solve the problem.
