### PR TITLE
create-gcloud-instance: require containers when using runner

### DIFF
--- a/create-gcloud-instance/config_runner.sh
+++ b/create-gcloud-instance/config_runner.sh
@@ -3,7 +3,8 @@ set -eo pipefail
 
 cd /home/actions/actions-runner || exit
 
-echo 'GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=1' >> .env
+echo 'ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER=1
+GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=1' >> .env
 
 # shellcheck disable=SC2154
 # SC2154: REPOSITORY_NAME/VM_TOKEN/RUNNER_NAME is referenced but not assigned:


### PR DESCRIPTION
Making use of a security feature released in 2.293.0 yesterday.