### PR TITLE
Update bottles failure and output composite action

### DIFF
--- a/failures-summary-and-bottle-result/README.md
+++ b/failures-summary-and-bottle-result/README.md
@@ -8,4 +8,6 @@ An action that groups `cat bottles/steps_output.txt` and `cat bottles/bottle_out
 - name: Failures Summary and Bottle Result
   if: always()
   uses: Homebrew/actions/failures-summary-and-bottle-result@master
+  with:
+    workdir: ${{ github.workspace }}
 ```

--- a/failures-summary-and-bottle-result/action.yml
+++ b/failures-summary-and-bottle-result/action.yml
@@ -1,7 +1,7 @@
 name: Failures summary and bottle result
 description: Output the logs of the bottle generation and a summary of all step failures
 inputs:
-  workdir: 
+  workdir:
     description: Working directory of the result
     required: true
     default: ${{ github.workspace }}

--- a/failures-summary-and-bottle-result/action.yml
+++ b/failures-summary-and-bottle-result/action.yml
@@ -1,17 +1,21 @@
 name: Failures summary and bottle result
 description: Output the logs of the bottle generation and a summary of all step failures
+inputs:
+  workdir: 
+    description: Working directory of the result
+    required: true
+    default: ${{ github.workspace }}
 
 runs:
   using: composite
   steps:
     - run: |
-        touch bottles/steps_output.txt
-        cat bottles/steps_output.txt
-        rm bottles/steps_output.txt
+        touch ${{ inputs.workdir }}/bottles/steps_output.txt
+        cat ${{ inputs.workdir }}/bottles/steps_output.txt
+        rm ${{ inputs.workdir }}/bottles/steps_output.txt
       shell: bash
 
     - run: |
-        cat bottles/bottle_output.txt
-        rm bottles/bottle_output.txt
+        cat ${{ inputs.workdir }}/bottles/bottle_output.txt
+        rm ${{ inputs.workdir }}/bottles/bottle_output.txt
       shell: bash
-


### PR DESCRIPTION
Based on the PR on Homebrew/homebrew-core#106155 the composite action will fail if we run it on Linux.
This is because the tests on Linux are using custom `workdir`. Thus, we need to somehow pass that directory to the composite action and make the tasks run in the appropriate directory. 
In this PR, I propose the approach to use `inputs`. Any feedback would be appreciated. Thank you.