### PR TITLE
failures-summary: exit early if file is empty or nonexistent

### DIFF
--- a/failures-summary-and-bottle-result/action.yml
+++ b/failures-summary-and-bottle-result/action.yml
@@ -26,7 +26,7 @@ runs:
 
         full_result_path="${{ inputs.workdir }}/${{ inputs.result_path }}"
 
-        touch "$full_result_path"
+        [[ -s "$full_result_path" ]] || exit 0
 
         echo '### ${{ inputs.step_name }}' >> "$GITHUB_STEP_SUMMARY"
         printf '```\n' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
This will prevent the summary from showing empty code blocks, such as in https://github.com/Homebrew/homebrew-core/actions/runs/2883783371/attempts/1#summary-7902798764.
