### PR TITLE
setup-gems-cache: Add composite action for setup gems cache

### DIFF
--- a/setup-cache/action.yml
+++ b/setup-cache/action.yml
@@ -1,0 +1,33 @@
+name: Setup Cache
+description: Setup Cache for workflow
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+      with:
+        test-bot: false
+
+    # Workaround until the `cache` action uses the changes from
+    # https://github.com/actions/toolkit/pull/580.
+    - name: Unlink workspace
+      run: |
+        rm "${GITHUB_WORKSPACE}"
+        mkdir "${GITHUB_WORKSPACE}"
+      shell: bash
+
+    - name: Cache Homebrew Gems
+      id: cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+        key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+        restore-keys: ${{ runner.os }}-rubygems-
+
+    - name: Install Homebrew Gems
+      id: gems
+      run: brew install-bundler-gems
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash

--- a/setup-cache/action.yml
+++ b/setup-cache/action.yml
@@ -63,7 +63,12 @@ runs:
     - name: Unlink workspace
       run: |
         # Unlink workspace
-        rm "${GITHUB_WORKSPACE}"
+        if [[ ${{ inputs.ci_test_mode }} == "1" ]]
+        then
+          mv "${GITHUB_WORKSPACE}" "${GITHUB_WORKSPACE}-link"
+        else
+          rm "${GITHUB_WORKSPACE}"
+        fi
         mkdir "${GITHUB_WORKSPACE}"
       shell: bash
 

--- a/setup-cache/action.yml
+++ b/setup-cache/action.yml
@@ -24,6 +24,7 @@ runs:
       
     - name: Clean up CI machine
       run: |
+        # Clean up CI machine
         if ! brew list --cask visual-studio &>/dev/null; then
           if ! rm -r '/Applications/Visual Studio.app'; then
             echo '::warning::Removing Visual Studio is no longer necessary.'
@@ -61,6 +62,7 @@ runs:
     # https://github.com/actions/toolkit/pull/580.
     - name: Unlink workspace
       run: |
+        # Unlink workspace
         rm "${GITHUB_WORKSPACE}"
         mkdir "${GITHUB_WORKSPACE}"
       shell: bash
@@ -77,6 +79,7 @@ runs:
     # https://github.com/actions/toolkit/pull/580.
     - name: Re-link workspace
       run: |
+        # Re-link workspace
         rmdir "${GITHUB_WORKSPACE}"
         mv "${GITHUB_WORKSPACE}-link" "${GITHUB_WORKSPACE}"
       if: inputs.ci_test_mode == '1'
@@ -84,6 +87,8 @@ runs:
 
     - name: Install Homebrew Gems
       id: gems
-      run: brew install-bundler-gems
+      run: |
+        # Install Homebrew Gems
+        brew install-bundler-gems
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash

--- a/setup-cache/action.yml
+++ b/setup-cache/action.yml
@@ -1,5 +1,10 @@
 name: Setup Cache
 description: Setup Cache for workflow
+inputs:
+  ci_test_mode: 
+    description: Determine the composite action behavior on normal and ci test mode
+    required: false
+    default: '0'
 
 runs:
   using: composite
@@ -9,6 +14,48 @@ runs:
       uses: Homebrew/actions/setup-homebrew@master
       with:
         test-bot: false
+
+    - name: Check out Pull Request
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+      if: inputs.ci_test_mode == '1'
+      
+    - name: Clean up CI machine
+      run: |
+        if ! brew list --cask visual-studio &>/dev/null; then
+          if ! rm -r '/Applications/Visual Studio.app'; then
+            echo '::warning::Removing Visual Studio is no longer necessary.'
+          fi
+        fi
+        
+        if ! brew uninstall --cask julia && ! rm -r /Applications/Julia-*.app; then
+          echo '::warning::Removing Julia is no longer necessary.'
+        fi
+
+        if ! rm /usr/local/share/man/man1/al.1 || \
+            ! sudo rm /etc/paths.d/mono-commands || \
+            ! sudo rm -r /Library/Frameworks/Mono.framework || \
+            ! sudo pkgutil --forget com.xamarin.mono-MDK.pkg; then
+          echo '::warning::Uninstalling Mono is no longer necessary.'
+        fi
+
+        if ! rm /usr/local/bin/dotnet; then
+          echo '::warning::Removing `dotnet` symlink is no longer necessary.'
+        fi
+
+        if ! rm /usr/local/bin/pod; then
+          echo '::warning::Removing `cocoapods` symlink is no longer necessary.'
+        fi
+
+        if ! rm /usr/local/bin/conda; then
+          echo '::warning::Removing `conda` symlink is no longer necessary.'
+        fi
+
+        brew unlink python && brew link --overwrite python
+      if: runner.os == 'macOS' && inputs.ci_test_mode == '1'
+      shell: bash
 
     # Workaround until the `cache` action uses the changes from
     # https://github.com/actions/toolkit/pull/580.
@@ -25,6 +72,15 @@ runs:
         path: ${{ steps.set-up-homebrew.outputs.gems-path }}
         key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
         restore-keys: ${{ runner.os }}-rubygems-
+        
+    # Workaround until the `cache` action uses the changes from
+    # https://github.com/actions/toolkit/pull/580.
+    - name: Re-link workspace
+      run: |
+        rmdir "${GITHUB_WORKSPACE}"
+        mv "${GITHUB_WORKSPACE}-link" "${GITHUB_WORKSPACE}"
+      if: inputs.ci_test_mode == '1'
+      shell: bash
 
     - name: Install Homebrew Gems
       id: gems

--- a/setup-gems-cache/README.md
+++ b/setup-gems-cache/README.md
@@ -1,0 +1,16 @@
+# Setup Gems Cache
+
+An action that prepare and setup gems cache.
+
+## Usage
+
+```yaml
+- name: Setup Gems Cache
+  if: always()
+  uses: Homebrew/actions/setup-gems-cache@master
+  with: 
+    ci_test_mode: 0
+    relink: 0
+    gems-path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+    gems-hash: ${{ steps.set-up-homebrew.outputs.gems-hash }}
+```

--- a/setup-gems-cache/action.yml
+++ b/setup-gems-cache/action.yml
@@ -9,6 +9,12 @@ inputs:
     description: Enable relink specific behavior on the composite action
     required: false
     default: '0'
+  gems-path:
+    description: Path to be used as input to cache action
+    required: true
+  gems-hash:
+    description: Hash string to be used as input to cache action
+    required: true
 
 runs:
   using: composite
@@ -74,8 +80,8 @@ runs:
       id: cache
       uses: actions/cache@v3
       with:
-        path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-        key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+        path: ${{ inputs.gems-path }}
+        key: ${{ runner.os }}-rubygems-${{ inputs.gems-hash }}
         restore-keys: ${{ runner.os }}-rubygems-
         
     # Workaround until the `cache` action uses the changes from

--- a/setup-gems-cache/action.yml
+++ b/setup-gems-cache/action.yml
@@ -1,20 +1,18 @@
-name: Setup Cache
-description: Setup Cache for workflow
+name: Setup Gems Cache
+description: Setup Gems Caching for workflow
 inputs:
   ci_test_mode: 
     description: Determine the composite action behavior on normal and ci test mode
+    required: false
+    default: '0'
+  relink: 
+    description: Enable relink specific behavior on the composite action
     required: false
     default: '0'
 
 runs:
   using: composite
   steps:
-    - name: Set up Homebrew
-      id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
-      with:
-        test-bot: false
-
     - name: Check out Pull Request
       uses: actions/checkout@v3
       with:
@@ -63,7 +61,7 @@ runs:
     - name: Unlink workspace
       run: |
         # Unlink workspace
-        if [[ ${{ inputs.ci_test_mode }} == "1" ]]
+        if [[ ${{ inputs.relink }} == "1" ]]
         then
           mv "${GITHUB_WORKSPACE}" "${GITHUB_WORKSPACE}-link"
         else
@@ -87,7 +85,7 @@ runs:
         # Re-link workspace
         rmdir "${GITHUB_WORKSPACE}"
         mv "${GITHUB_WORKSPACE}-link" "${GITHUB_WORKSPACE}"
-      if: inputs.ci_test_mode == '1'
+      if: inputs.relink == '1'
       shell: bash
 
     - name: Install Homebrew Gems


### PR DESCRIPTION
Several action workflow on the homebrew repository have common steps for setup and checking for gems cache. Why don't we group this together and make composite action out of it? 

Several example of the workflow can be found on [cache.yml](https://github.com/mohzulfikar-org/homebrew-cask/blob/master/.github/workflows/cache.yml) or [ci.yml](https://github.com/mohzulfikar-org/homebrew-cask/blob/master/.github/workflows/ci.yml) on the homebrew-cask repository. Any feedback would be appreciated. Thank you.