### PR TITLE
setup-homebrew: private repositories support

### DIFF
--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: false
   token:
-    description: Token to be used for authenticating to Github (if using private repositories)
+    description: Token to be used for GitHub authentication (if using private repositories)
     required: false
     default: ''
 outputs:

--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Show debugging output
     required: false
     default: false
+  token:
+    description: Token to be used for authenticating to Github (if using private repositories)
+    required: false
+    default: ''
 outputs:
   gems-path:
     description: Homebrew's Ruby gems path
@@ -24,6 +28,6 @@ runs:
   using: composite
   steps:
     - run: |
-        "$GITHUB_ACTION_PATH/main.sh" '${{ inputs.test-bot }}' '${{ inputs.debug }}'
+        "$GITHUB_ACTION_PATH/main.sh" '${{ inputs.test-bot }}' '${{ inputs.debug }}' '${{ inputs.token }}'
       shell: bash
       id: setup

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -42,7 +42,7 @@ HOMEBREW_CORE_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-co
 HOMEBREW_CASK_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-cask"
 
 # Use an access token to checkout (private repositories)
-if [[ ! -z "${TOKEN}" ]]; then
+if [[ -n "${TOKEN}" ]]; then
     git config --global url."https://api:${TOKEN}@github.com/".insteadOf "https://github.com/"
 fi
 

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 TEST_BOT="${1}"
 DEBUG="${2}"
+TOKEN="${3}"
 
 if [[ "${DEBUG}" == 'true' ]]; then
   set -x
@@ -39,6 +40,11 @@ HOMEBREW_PREFIX="$(brew --prefix)"
 HOMEBREW_REPOSITORY="$(brew --repo)"
 HOMEBREW_CORE_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core"
 HOMEBREW_CASK_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-cask"
+
+# Use an access token to checkout (private repositories)
+if [[ ! -z "${TOKEN}" ]]; then
+    git config --global url."https://api:${TOKEN}@github.com/".insteadOf "https://github.com/"
+fi
 
 # Do in container or on the runner
 if [[ -f /proc/1/cgroup ]] && grep -qE "actions_job|docker" /proc/1/cgroup; then


### PR DESCRIPTION
fixes #236 

Allow passing the github api token (`GITHUB_TOKEN`) to authenticate with private repositories.

Example:
```yml
    steps:
      - name: Set up Homebrew
        id: set-up-homebrew
        uses: Homebrew/actions/setup-homebrew@master
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
```