### PR TITLE
upload-and-cleanup-bottle-result: Add composite action for uploading and cleaning up bottle

### DIFF
--- a/upload-and-cleanup-bottle-result/README.md
+++ b/upload-and-cleanup-bottle-result/README.md
@@ -1,0 +1,13 @@
+# Upload and Cleanup Bottle Result
+
+An action that upload and cleanup bottle result.
+
+## Usage
+
+```yaml
+- name: Upload and Cleanup Bottle Result
+  if: always()
+  uses: Homebrew/actions/upload-and-cleanup-bottle-result@master
+  with:
+    workdir: ${{ github.workspace }}
+```

--- a/upload-and-cleanup-bottle-result/action.yml
+++ b/upload-and-cleanup-bottle-result/action.yml
@@ -1,0 +1,86 @@
+name: Upload and Cleanup Bottle Result
+description: Upload and Cleanup Bottle logs and result
+inputs:
+  workdir:
+    description: Working directory of the result
+    required: true
+    default: ${{ github.workspace }}
+
+runs:
+  using: composite
+  steps:
+    - name: Upload logs
+      if: always()
+      uses: actions/upload-artifact@main
+      with:
+        name: logs-${{ matrix.runner }}
+        path: ${{ inputs.workdir }}/bottles/logs
+
+    - name: Delete logs and home
+      if: always()
+      run: |
+        # Delete logs and home
+        rm -rvf bottles/logs
+        rm -rvf bottles/home
+      shell: bash
+
+    - name: ls bottles and see all
+      if: always()
+      run: |
+        ls -alh ${{ inputs.workdir }}/bottles
+      shell: bash
+
+    - name: ls bottles/failed and see all
+      if: always()
+      run: |
+        ls -alh ${{ inputs.workdir }}/bottles/failed || true
+      shell: bash
+
+    - name: Count bottles
+      id: bottles
+      if: always()
+      run: |
+        # Count bottles
+        cd ${{ inputs.workdir }}/bottles
+        count=$(ls *.json | wc -l | xargs echo -n)
+        echo "$count bottles"
+        echo "::set-output name=count::$count"
+        failures=$(ls failed/*.json | wc -l | xargs echo -n)
+        echo "$failures failed bottles"
+        echo "::set-output name=failures::$failures"
+      shell: /bin/bash -e {0}
+
+    - name: Upload failed bottles
+      if: always() && steps.bottles.outputs.failures > 0
+      uses: actions/upload-artifact@main
+      with:
+        name: bottles-${{ matrix.runner }}
+        path: ${{ inputs.workdir }}/bottles/failed
+
+    # Must be run before the `Upload bottles` step so that failed
+    # bottles are not included in the `bottles` artifact.
+    - name: Delete failed bottles
+      if: always()
+      run: |
+        # Delete failed bottles
+        rm -rvf ${{ inputs.workdir }}/bottles/failed
+      shell: bash
+
+    - name: Upload bottles
+      if: always() && steps.bottles.outputs.count > 0
+      uses: actions/upload-artifact@main
+      with:
+        name: bottles
+        path: ${{ inputs.workdir }}/bottles
+
+    - name: Post cleanup
+      if: always()
+      run: |
+        # Post cleanup
+        if [ "$RUNNER_OS" = 'Linux' ]; then
+          docker rm -f ${{github.sha}}
+        else
+          brew test-bot --only-cleanup-after
+        fi
+        rm -rvf ${{ inputs.workdir }}/bottles
+      shell: bash

--- a/upload-and-cleanup-bottle-result/action.yml
+++ b/upload-and-cleanup-bottle-result/action.yml
@@ -5,6 +5,14 @@ inputs:
     description: Working directory of the result
     required: true
     default: ${{ github.workspace }}
+  remove-linuxbrew-image:
+    description: Cleanup linuxbrew docker container
+    required: false
+    default: "0"
+  include-failed-bottles:
+    description: Upload failed bottles artifact
+    required: false
+    default: "0"
 
 runs:
   using: composite
@@ -19,21 +27,9 @@ runs:
     - name: Delete logs and home
       if: always()
       run: |
-        # Delete logs and home
-        rm -rvf bottles/logs
-        rm -rvf bottles/home
-      shell: bash
-
-    - name: ls bottles and see all
-      if: always()
-      run: |
-        ls -alh ${{ inputs.workdir }}/bottles
-      shell: bash
-
-    - name: ls bottles/failed and see all
-      if: always()
-      run: |
-        ls -alh ${{ inputs.workdir }}/bottles/failed || true
+        # Delete bottles logs and home
+        rm -rvf ${{ inputs.workdir }}/bottles/logs
+        rm -rvf ${{ inputs.workdir }}/bottles/home
       shell: bash
 
     - name: Count bottles
@@ -45,13 +41,16 @@ runs:
         count=$(ls *.json | wc -l | xargs echo -n)
         echo "$count bottles"
         echo "::set-output name=count::$count"
-        failures=$(ls failed/*.json | wc -l | xargs echo -n)
-        echo "$failures failed bottles"
-        echo "::set-output name=failures::$failures"
+        if [[ ${{ inputs.include-failed-bottles }} == "1" ]]
+        then
+          failures=$(ls failed/*.json | wc -l | xargs echo -n)
+          echo "$failures failed bottles"
+          echo "::set-output name=failures::$failures"
+        fi
       shell: /bin/bash -e {0}
 
     - name: Upload failed bottles
-      if: always() && steps.bottles.outputs.failures > 0
+      if: always() && steps.bottles.outputs.failures > 0 && inputs.include-failed-bottles == 1
       uses: actions/upload-artifact@main
       with:
         name: bottles-${{ matrix.runner }}
@@ -77,7 +76,7 @@ runs:
       if: always()
       run: |
         # Post cleanup
-        if [ "$RUNNER_OS" = 'Linux' ]; then
+        if [ "${{ inputs.remove-linuxbrew-image }}" = "1" ] && [ "$RUNNER_OS" = "Linux" ]; then
           docker rm -f ${{github.sha}}
         else
           brew test-bot --only-cleanup-after


### PR DESCRIPTION
On [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core), the upload and cleaning up bottle results are repetitive in several workflows with only minor differences ([tests.yml](https://github.com/Homebrew/homebrew-core/blob/master/.github/workflows/tests.yml), [dispatch-build-bottle.yml](https://github.com/Homebrew/homebrew-core/blob/master/.github/workflows/dispatch-build-bottle.yml), [dispatch-rebottle.yml](https://github.com/Homebrew/homebrew-core/blob/master/.github/workflows/dispatch-rebottle.yml)). I think, we could group the steps into the composite action instead.

cc: @mistydemeo 