### PR TITLE
workflows/setup-homebrew: run tap syntax on `ubuntu-latest`

### DIFF
--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -45,6 +45,3 @@ jobs:
       - run: brew test-bot --only-setup
 
       - run: brew test-bot --only-tap-syntax
-        # temporary disable this until brew audit is fixed here
-        # see https://github.com/Homebrew/actions/pull/308
-        if: matrix.os != 'ubuntu-latest'


### PR DESCRIPTION
I think this should be working now.
