### PR TITLE
setup-homebrew/main.sh: add sbin.

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -53,6 +53,7 @@ if [[ -f "/.dockerenv" ]] || ([[ -f /proc/1/cgroup ]] && grep -qE "actions_job|d
 else
     # Add brew to PATH
     echo "$HOMEBREW_PREFIX/bin" >> $GITHUB_PATH
+    echo "$HOMEBREW_PREFIX/sbin" >> $GITHUB_PATH
 fi
 
 # Use an access token to checkout (private repositories)


### PR DESCRIPTION
Let's also add `sbin` to the `GITHUB_PATH` to stop complaints about it not being added e.g. https://github.com/Homebrew/brew/actions/runs/3429149696/jobs/5714410626#step:7:94