### PR TITLE
label-pull-requests: add `keep_if_any_match` field

### DIFF
--- a/label-pull-requests/README.md
+++ b/label-pull-requests/README.md
@@ -48,8 +48,14 @@ Will remove labels from a pull request that no longer apply.
               "pr_body_content": "Created with `brew bump-formula-pr`"
           },
           {
-            "label": "documentation",
-            "path": ".*\\.md"
+              "label": "documentation",
+              "path": ".*\\.md"
+          },
+          {
+              "label": "long build",
+              "path": "Formula/(gcc|llvm|qt)(@[0-9]+)?.rb",
+              "keep_if_no_match": true,
+              "keep_if_any_match": true
           }
       ]
 ```
@@ -89,4 +95,9 @@ Will remove labels from a pull request that no longer apply.
 
       - label: documentation
         path: .*\.md
+
+      - label: long build
+        path: Formula/(gcc|llvm|qt)(@[0-9]+)?.rb
+        keep_if_no_match: true
+        keep_if_any_match: true
 ```

--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -135,6 +135,9 @@ async function main() {
             if (matchingFiles.length == files.data.length) {
                 continue
             }
+            if (constraint.wanted && constraint.keep_if_any_match) {
+                continue
+            }
 
             constraintToMatchingFiles.delete(constraint)
         }
@@ -154,8 +157,8 @@ async function main() {
             }
 
             if (body) {
-            	constraintApplies = body.match(constraint.pr_body_content)
-	    }
+                constraintApplies = body.match(constraint.pr_body_content)
+            }
 
             if (labelExists && constraintApplies) {
                 continue


### PR DESCRIPTION
Looking into way to label PRs that may be opened with multiple files/commits. For example, `llvm` PRs opened with `ccls` revision bump which are not getting labelled with `long build` + `CI-linux-self-hosted`.