### PR TITLE
More CI fixes

### DIFF
--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -8,6 +8,9 @@ on:
       - 'package-lock.json'
       - 'node_modules/**'
 
+permissions:
+  actions: write
+
 jobs:
   cancel:
     runs-on: ubuntu-latest

--- a/create-gcloud-instance/setup.sh
+++ b/create-gcloud-instance/setup.sh
@@ -8,12 +8,13 @@ GITHUB_TOKEN=$(curl http://metadata.google.internal/computeMetadata/v1/instance/
 
 # Initial setup: setup docker and github actions runner.
 # This is done only once, if the machine is stopped/started, this block of code is not executed again.
-if [ ! -d "/home/actions" ]; then
+if [[ ! -d "/home/actions" ]]; then
     # Setup docker
     apt-get -y update && apt-get install -y curl apt-transport-https ca-certificates software-properties-common jq wget
 
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    codename=$(lsb_release -cs)
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu ${codename} stable"
 
     apt-get update
 


### PR DESCRIPTION
Missed the permissions of `cancel-previous-runs`.

Fix style in `create-gcloud-instance`. I guess shellcheck updated at some point or something.