### PR TITLE
Various improvements to setup-homebrew

### DIFF
--- a/.github/workflows/setup-commit-signing.yml
+++ b/.github/workflows/setup-commit-signing.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   commit-signing:
+    if: github.repository_owner == 'Homebrew'
     strategy:
       matrix:
         container:

--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -11,15 +11,42 @@ on:
 jobs:
   setup:
     strategy:
+      fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - ubuntu-22.04
-          - macOS-latest
-    runs-on: ${{matrix.os}}
+        include:
+          - os: macos-latest
+            key: macos
+          - os: ubuntu-18.04
+            key: ubuntu-18
+          - os: ubuntu-22.04
+            key: ubuntu-22
+          - os: ubuntu-22.04
+            key: docker-root
+            container:
+              image: ghcr.io/homebrew/ubuntu22.04:master
+              options: --user=root
+          - os: ubuntu-22.04
+            key: docker-linuxbrew
+            container:
+              image: ghcr.io/homebrew/ubuntu22.04:master
+              options: --user=linuxbrew
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        run: |
+          # Allow writing under linuxbrew user
+          orig_uid=$(ls -nd $GITHUB_WORKSPACE | awk 'NR==1 {print $3}')
+          sudo chown -R $(whoami) $GITHUB_WORKSPACE $HOME
+
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git init
+          git remote add origin $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+          git fetch --no-tags --depth=1 origin $GITHUB_SHA
+          git checkout --force $GITHUB_SHA
+
+          # Reset ownership so we test if the equivalent in setup-homebrew works.
+          sudo chown -R $orig_uid $GITHUB_WORKSPACE $HOME
 
       - name: Check syntax
         run: bash -n setup-homebrew/*.sh
@@ -33,8 +60,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
+          key: ${{ matrix.key }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.key }}-rubygems-
 
       - name: Install Homebrew Bundler RubyGems
         if: steps.cache.outputs.cache-hit != 'true'

--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -14,20 +14,17 @@ inputs:
     required: false
     default: false
   token:
-    description: Token to be used for GitHub authentication (if using private repositories)
+    description: Token to be used for GitHub authentication (if using private repositories). This token will persist through other steps for the duration of the job.
     required: false
     default: ''
 outputs:
+  repository-path:
+    description: Path to where the repository has been checked out (if applicable)
   gems-path:
     description: Homebrew's Ruby gems path
-    value: ${{steps.setup.outputs.gems-path}}
   gems-hash:
     description: Homebrew's Ruby Gemfile.lock sha256sum
-    value: ${{steps.setup.outputs.gems-hash}}
 runs:
-  using: composite
-  steps:
-    - run: |
-        "$GITHUB_ACTION_PATH/main.sh" '${{ inputs.test-bot }}' '${{ inputs.debug }}' '${{ inputs.token }}'
-      shell: bash
-      id: setup
+  using: node16
+  main: main.mjs
+  post: post.mjs

--- a/setup-homebrew/main.mjs
+++ b/setup-homebrew/main.mjs
@@ -1,0 +1,14 @@
+import {exec} from "@actions/exec"
+import core from "@actions/core"
+
+// GitHub Actions does not support shell `post` actions and thus requires a JS wrapper.
+try {
+  await exec("bash", [
+    new URL("./main.sh", import.meta.url).pathname,
+    core.getInput("test-bot"),
+    core.getInput("debug"),
+    core.getInput("token")
+  ])
+} catch (error) {
+  core.setFailed(error.message)
+}

--- a/setup-homebrew/post.mjs
+++ b/setup-homebrew/post.mjs
@@ -1,0 +1,12 @@
+import {exec} from "@actions/exec"
+import core from "@actions/core"
+
+// GitHub Actions does not support shell `post` actions and thus requires a JS wrapper.
+try {
+  await exec("bash", [
+    new URL("./post.sh", import.meta.url).pathname,
+    core.getInput("debug")
+  ])
+} catch (error) {
+  core.setFailed(error.message)
+}

--- a/setup-homebrew/post.sh
+++ b/setup-homebrew/post.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Cleanup script to restore the state of the system to as it was when the job started.
+
+set -euo pipefail
+
+DEBUG="${1}"
+
+if [[ "${DEBUG}" == 'true' ]]; then
+  set -x
+fi
+
+# Remove symlink and move files back.
+if [[ -n "${STATE_TAP_SYMLINK-}" ]]; then
+  rm "${STATE_TAP_SYMLINK}"
+  mkdir "${STATE_TAP_SYMLINK}"
+  (shopt -s dotglob; mv "${GITHUB_WORKSPACE}"/* "${STATE_TAP_SYMLINK}" )
+  echo "Reset tap symlink."
+fi
+
+# Remove (potentially sensitive) token.
+if [[ -n "${STATE_TOKEN_SET-}" ]]; then
+  git config --global --unset-all "http.${GITHUB_SERVER_URL}/.extraheader"
+  echo "Removed token."
+fi
+
+# Restore permissions to as they were before.
+if [[ -n "${STATE_SETFACL_DIRECTORIES-}" ]]; then
+  (IFS=:; sudo setfacl -Rb ${STATE_SETFACL_DIRECTORIES})
+  echo "Reset permissions."
+fi


### PR DESCRIPTION
Docker file ownership:
* Replace `chown` logic with `setfacl`.
  - This allows the original permissions to not be disrupted, which the runner may need (and does for the new file commands).
* Increase to cover `RUNNER_TEMP`, including file commands (e.g. `GITHUB_OUTPUT`).
* Reset directories to original ACL/permissions after job completes.

Tokens:
* Adjust token behaviour to use HTTP headers rather than URL authentication.
  - This matches how `actions/checkout` behaves.
* Cleanup token config after the job completes.
  - This is a security enchancement.
* Document that tokens persist through job steps.

GitHub workspace:
* Remove `GITHUB_WORKSPACE` replacement for Homebrew/brew and Homebrew/homebrew-core.
  - ⚠️ This is a breaking change affecting those repositories only.
* Adjust `GITHUB_WORKSPACE` handling for other taps to instead clone to the original `GITHUB_WORKSPACE` directory and symlink the tap location to it, rather than vice versa.
  - This has a slight compatibility concern, albeit hopefully not noticeable.
  - This fixes various compatibility issues with actions assuming `GITHUB_WORKSPACE` is untampered.
  - This operation is now cleaned up and undone when the job completes.
  - This behaviour continues (as before) to not apply to container jobs.
* Add `repository-path` output for Homebrew/brew and all taps, pointing to the relevant path matching `GITHUB_REPOSITORY`

Safe directory:
* Whitelist all Homebrew repositories in git's `safe.directory` config when running in a container.
  - This fixes errors when running not as the `linuxbrew` user.
  - This whitelisting action is currently only supported in container jobs.

Other:
* Replace `set-output` with `GITHUB_OUTPUT` file command.
* Move `sbin` to lower priority than `bin`.
  - This makes the behaviour consistent to `brew shellenv`.
* Remove Linux-specific permission changes (experimental - might drop this if `brew tests` fails).