### PR TITLE
setup-homebrew: handle installs without Homebrew/core tapped

### DIFF
--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -71,4 +71,4 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - run: brew test-bot --only-tap-syntax
+      - run: brew info hello


### PR DESCRIPTION
For CI outside of Homebrew/core, I've set cloning to be gated around `HOMEBREW_NO_INSTALL_FROM_API`. Core cloning is very slow so I'm trying to avoid there where possible.