### PR TITLE
Replace deprecated `set-output` command

### DIFF
--- a/.github/workflows/vendor-node-modules.yml
+++ b/.github/workflows/vendor-node-modules.yml
@@ -44,7 +44,7 @@ jobs:
           gh pr checkout '${{ github.event.pull_request.number || github.event.inputs.pull_request }}'
 
           branch="$(git branch --show-current)"
-          echo "::set-output name=branch::${branch}"
+          echo "branch=${branch}" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Vendor node_modules
@@ -57,7 +57,7 @@ jobs:
           if ! git diff --stat --exit-code node_modules; then
             git add node_modules
             git commit -m "node_modules: update"
-            echo "::set-output name=committed::true"
+            echo "committed=true" >> $GITHUB_OUTPUT
           fi
       - name: Push to pull request
         if: steps.commit.outputs.committed == 'true'

--- a/remove-disabled-formulae/main.rb
+++ b/remove-disabled-formulae/main.rb
@@ -36,4 +36,4 @@ formulae_to_remove.each do |formula|
   git '-C', tap_dir.to_s, 'commit', formula.path.to_s, '--message', "#{formula.name}: remove formula", '--quiet'
 end
 
-puts '::set-output name=formulae-removed::true'
+File.open(ENV['GITHUB_OUTPUT'], 'a') { |f| f.puts('formulae-removed=true') }

--- a/review-cask-pr/review.rb
+++ b/review-cask-pr/review.rb
@@ -177,8 +177,10 @@ begin
 
       puts message
 
-      puts "::set-output name=event::#{event}"
-      puts "::set-output name=message::#{GitHub::Actions.escape(message)}"
+      File.open(ENV["GITHUB_OUTPUT"], "a") do |f|
+        f.puts("event=#{event}")
+        f.puts(GitHub::Actions.format_multiline_string("message", message))
+      end
     end
   when %r{^https://github.com/([^\/]+)/([^\/]+)/pull/(\d+)}
     owner = Regexp.last_match[1]


### PR DESCRIPTION
See here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

TL;DR: The `set-output` command has been deprecated and we should be writing to the `$GITHUB_OUTPUT` environment file instead.

Old syntax:
```
- name: Set output
  run: echo "::set-output name={name}::{value}"
```

New syntax:
```
- name: Set output
  run: echo "{name}={value}" >> $GITHUB_OUTPUT
```