### PR TITLE
git-try-push: skip initial push without force when `no_lease`

### DIFF
--- a/git-try-push/main.js
+++ b/git-try-push/main.js
@@ -46,8 +46,11 @@ async function main() {
         for (let i = 0; i < tries; i++) {
             try {
                 // Try to push, if successful, then checkout previous branch and just exit.
-                // Don't try to force push the first time in case it's not necessary.
-                if (force && i>0)
+				// If force pushing with lease, don't try to force push the first time
+				// in case it's not necessary.
+				// If force pushing without lease, force push the first time since we've
+				// already decided we don't care about having outdated refs.
+                if (force && ((i > 0) || no_lease))
                     await exec.exec(git, ["push", force_flag, remote, branch])
                 else
                     await exec.exec(git, ["push", remote, branch])


### PR DESCRIPTION
The pull-and-rebase step that this action does upon failure of the
initial `git push` (without force) destroys the changes we were trying
to force push in the first place.

Let's fix that by pushing with force right from the beginning. We've
already decided we're willing to destroy changes on the target branch,
so let's skip the initial `git push` which we already know is going to
fail.

See Homebrew/homebrew-core#126950 for additional context.
