### PR TITLE
Don't count deleted files for `missing_content` constraint.

### DIFF
--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -264,7 +264,7 @@ function doesConstraintApply(constraint, file) {
             return false
         }
 
-	if (Array.isArray(constraint.missing_content)) {
+        if (Array.isArray(constraint.missing_content)) {
             for (const content of constraint.missing_content) {
                 if (file.content.match(content)) {
                     return false

--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -259,7 +259,12 @@ function doesConstraintApply(constraint, file) {
     }
 
     if (constraint.missing_content) {
-        if (Array.isArray(constraint.missing_content)) {
+	// Deleted files cannot be missing content.
+	if (file.status == 'removed') {
+            return false
+	}
+
+	if (Array.isArray(constraint.missing_content)) {
             for (const content of constraint.missing_content) {
                 if (file.content.match(content)) {
                     return false

--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -259,10 +259,10 @@ function doesConstraintApply(constraint, file) {
     }
 
     if (constraint.missing_content) {
-	// Deleted files cannot be missing content.
-	if (file.status == 'removed') {
+        // Deleted files cannot be missing content.
+        if (file.status == 'removed') {
             return false
-	}
+        }
 
 	if (Array.isArray(constraint.missing_content)) {
             for (const content of constraint.missing_content) {


### PR DESCRIPTION
Deleted files always match all `missing_content` constraints, adding superfluous labels.