### PR TITLE
check-commit-format: remove reference to autosquash

### DIFF
--- a/check-commit-format/main.js
+++ b/check-commit-format/main.js
@@ -57,7 +57,9 @@ async function main() {
 
                 // We've already modified this file, or the commit subject doesn't start with the formula name.
                 if (files_touched.includes(file.filename) || !commit_subject.startsWith(formula)) {
-                    message = "Pull request will be autosquashed."
+                    is_success = false
+                    message = "Please squash your commits according to the style guide."
+                    break
                 }
                 files_touched.push(file.filename)
             } else if (file.filename.startsWith("Casks/")) {


### PR DESCRIPTION
We're no longer squashing commits by default, so let's update this
action to handle that accordingly.
