### PR TITLE
git-try-push: fix truth-y string arguments

### DIFF
--- a/git-try-push/main.js
+++ b/git-try-push/main.js
@@ -8,9 +8,9 @@ async function main() {
         const remote = core.getInput("remote", { required: true })
         const branch = core.getInput("branch", { required: true })
         const tries = core.getInput("tries", { required: true })
-        const force = core.getInput("force")
+        const force = String(core.getInput("force")) == "true"
         const origin_branch = core.getInput("origin_branch") || branch
-        const no_lease = core.getInput("no_lease")
+        const no_lease = String(core.getInput("no_lease")) == "true"
 
         const git = "/usr/bin/git"
 


### PR DESCRIPTION
When we pass `false` to `force` and `no_lease`, it is cast as a
`String`. Unfortunately, the string `'false'` is truth-y, so we've been
pushing with `--force` since we started using these inputs.

Let's fix that by making sure we interpret string arguments as intended.
