### PR TITLE
setup-homebrew: fix shellcheck errors

### DIFF
--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -78,3 +78,7 @@ jobs:
       - run: brew test-bot --only-setup
 
       - run: brew info hello
+
+      - run: brew install shellcheck
+
+      - run: shellcheck ./setup-homebrew/*.sh

--- a/setup-homebrew/post.sh
+++ b/setup-homebrew/post.sh
@@ -25,6 +25,7 @@ fi
 
 # Restore permissions to as they were before.
 if [[ -n "${STATE_SETFACL_DIRECTORIES-}" ]]; then
-  (IFS=:; sudo setfacl -Rb ${STATE_SETFACL_DIRECTORIES})
+  IFS=':' read -ra STATE_SETFACL_DIRECTORY_ARRAY <<< "$STATE_SETFACL_DIRECTORIES"
+  sudo setfacl -Rb "${STATE_SETFACL_DIRECTORY_ARRAY[@]}"
   echo "Reset permissions."
 fi


### PR DESCRIPTION
Also, run `shellcheck` in the test to avoid further errors.
