### PR TITLE
setup-homebrew: default `debug` to current runner debug state

### DIFF
--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -12,7 +12,7 @@ inputs:
   debug:
     description: Show debugging output
     required: false
-    default: false
+    default: ${{ runner.debug == '1' }}
   token:
     description: Token to be used for GitHub authentication (if using private repositories). This token will persist through other steps for the duration of the job.
     required: false


### PR DESCRIPTION
This makes the action run in debug mode if the runner is set to run in
debug mode.

See https://github.com/actions/github-script/blob/060d68304cc19ea84d828af10e34b9c6ca7bdb31/action.yml#L17
