### PR TITLE
failures-summary-and-bottle-result: change default workdir

### DIFF
--- a/failures-summary-and-bottle-result/action.yml
+++ b/failures-summary-and-bottle-result/action.yml
@@ -4,7 +4,7 @@ inputs:
   workdir:
     description: Working directory of the result
     required: true
-    default: ${{ github.workspace }}
+    default: ${{ env.BOTTLES_DIR }}
   result_path:
     description: Path to the result (relative to workdir)
     required: true


### PR DESCRIPTION
This is `${{ env.BOTTLES_DIR }}` everywhere we use it in Homebrew/core,
so let's make that the default here so we can skip having to specify it
at all.
