### PR TITLE
Revert "failures-summary-and-bottle-result: change default workdir"

### DIFF
--- a/failures-summary-and-bottle-result/action.yml
+++ b/failures-summary-and-bottle-result/action.yml
@@ -4,7 +4,7 @@ inputs:
   workdir:
     description: Working directory of the result
     required: true
-    default: ${{ env.BOTTLES_DIR }}
+    default: ${{ github.workspace }}
   result_path:
     description: Path to the result (relative to workdir)
     required: true


### PR DESCRIPTION
Unfortunately, we cannot use `env` for inputs to an action. [1]

This reverts commit 74ef7285a4bf1591dd5a672a0714aef8519dc766.

[1] https://github.com/Homebrew/homebrew-core/actions/runs/4795639651/jobs/8531057306?pr=129289
