### PR TITLE
count-bottles: fix "command not found" error

### DIFF
--- a/count-bottles/action.yml
+++ b/count-bottles/action.yml
@@ -22,7 +22,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: |
-        "$GITHUB_ACTION_PATH/count.sh" '${{ inputs.working-directory }}' '${{ inputs.debug }}'
+    - run: ./count.sh '${{ inputs.working-directory }}' '${{ inputs.debug }}'
+      working-directory: ${{ github.action_path }}
       shell: bash
       id: count

--- a/count-bottles/action.yml
+++ b/count-bottles/action.yml
@@ -22,6 +22,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: count.sh '${{ inputs.working-directory }}' '${{ inputs.debug }}'
+    - run: |
+        "$GITHUB_ACTION_PATH/count.sh" '${{ inputs.working-directory }}' '${{ inputs.debug }}'
       shell: bash
       id: count


### PR DESCRIPTION
This should fix the error seen in https://github.com/Homebrew/homebrew-core/actions/runs/4796638560/jobs/8532735898.

Cc @carlocab
