### PR TITLE
git-try-push: fix Sorbet and SPDX workflows in Homebrew/brew

### DIFF
--- a/git-try-push/action.yml
+++ b/git-try-push/action.yml
@@ -26,8 +26,11 @@ inputs:
   force:
     description: Whether to force-with-lease push (rebasing on origin_branch if needed)
     required: false
+  remote_branch:
+    description: Remote branch to push to, defaults to `branch`
+    required: false
   origin_branch:
-    description: Remote branch to rebase on and push to, defaults to branch
+    description: Remote branch to rebase on, defaults to `remote_branch`
     required: false
   no_lease:
     description: Whether to force push without lease (requires force)

--- a/git-try-push/action.yml
+++ b/git-try-push/action.yml
@@ -22,7 +22,7 @@ inputs:
   tries:
     description: How many times to try pushing
     required: false
-    default: "20"
+    default: "10"
   force:
     description: Whether to force-with-lease push (rebasing on origin_branch if needed)
     required: false

--- a/git-try-push/main.js
+++ b/git-try-push/main.js
@@ -69,7 +69,7 @@ async function main() {
             } catch (error) {
                 // Push failed. Wait some time (with an exponential backoff), pull changes with rebasing
                 // and try again.
-                const delay = (i+1)**2
+                const delay = 2 ** i
                 await exec.exec("sleep", [delay])
                 // `git pull` can also fail, so do the same retry procedure here.
                 for (let j = 0; j < tries; j++) {

--- a/git-try-push/main.js
+++ b/git-try-push/main.js
@@ -8,8 +8,9 @@ async function main() {
         const remote = core.getInput("remote", { required: true })
         const branch = core.getInput("branch", { required: true })
         const tries = core.getInput("tries", { required: true })
+        const remote_branch = core.getInput("remote_branch") || branch
+        const origin_branch = core.getInput("origin_branch") || remote_branch
         const force = String(core.getInput("force")) == "true"
-        const origin_branch = core.getInput("origin_branch") || branch
         const no_lease = String(core.getInput("no_lease")) == "true"
 
         const git = "/usr/bin/git"
@@ -21,14 +22,13 @@ async function main() {
             force_flag = "--force-with-lease"
         }
 
-        // We can use `${branch}:${origin_branch}` as a catch-all. But we want
-        // to simplify the log output a bit because `branch` and `origin_branch`
+        var refspec =`${branch}:${remote_branch}`
+
+        // We can use `${branch}:${remote_branch}` as a catch-all. But we want
+        // to simplify the log output a bit because `branch` and `remote_branch`
         // are often the same.
-        var refspec
-        if (branch == origin_branch) {
+        if (branch == remote_branch) {
             refspec = branch
-        } else {
-            refspec = `${branch}:${origin_branch}`
         }
 
         // Change directory.


### PR DESCRIPTION
The Sorbet and SPDX workflows use `origin_branch` as the branch to
rebase on but not push to. Let's restore that behaviour, but specify an
additional input, `remote_branch`, which specifies the remote branch
name to push to. This input will be needed in Homebrew/core.

While we're here, let's reduce the default number of tries so that the
workflow gives up after about 20 minutes instead of after almost an
hour.

- git-try-push: fix Sorbet and SPDX workflows in Homebrew/brew
- git-try-push: reduce default number of tries
