### PR TITLE
remove-disabled-formulae: unconditionally write to `GITHUB_OUTPUT`

### DIFF
--- a/remove-disabled-formulae/main.rb
+++ b/remove-disabled-formulae/main.rb
@@ -26,6 +26,7 @@ raise err unless status.success?
 
 if out.chomp.empty?
   puts 'No formulae removed.'
+  File.open(ENV['GITHUB_OUTPUT'], 'a') { |f| f.puts('formulae-removed=false') }
   exit
 end
 


### PR DESCRIPTION
This is needed by the changes in Homebrew/homebrew-core#129852.
