### PR TITLE
post-build: add debug output for `rm` error

### DIFF
--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -97,6 +97,10 @@ runs:
       if: always() && fromJson(inputs.cleanup)
       run: |
         brew test-bot --only-cleanup-after
+        if command -v lsof >/dev/null
+        then
+          lsof -x +D "$BOTTLES_DIR"
+        fi
         rm -rvf "${BOTTLES_DIR:?}"
       shell: bash
       env:


### PR DESCRIPTION
We keep seeing `Killed: 9` errors for the `rm` call in this step. I'm
hoping having a look at what might still be using this directory will
shed some light here.
