### PR TITLE
post-build: fix `Killed: 9` errors

### DIFF
--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -98,6 +98,6 @@ runs:
       run: |
         brew test-bot --only-cleanup-after
         rm -rvf "${BOTTLES_DIR:?}"
-      shell: bash
+      shell: /bin/bash -e {0}
       env:
         BOTTLES_DIR: ${{ inputs.bottles-directory }}


### PR DESCRIPTION
`--only-cleanup-after` wipes our shell, which causes succeeding commands
to fail.
