### PR TITLE
setup-homebrew: remove reliance on a functional brew Ruby

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -50,7 +50,7 @@ HOMEBREW_OTHER_CASK_REPOSITORIES=(
     "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask-versions"
 )
 if [[ "$GITHUB_REPOSITORY" =~ ^.+/homebrew-.+$ ]]; then
-    HOMEBREW_TAP_REPOSITORY="$(brew --repo "$GITHUB_REPOSITORY")"
+    HOMEBREW_TAP_REPOSITORY="$HOMEBREW_REPOSITORY/Library/Taps/$(echo "$GITHUB_REPOSITORY" | tr "[:upper:]" "[:lower:]")"
 fi
 
 # Do in container or on the runner


### PR DESCRIPTION
Just like how `brew update` is able to work if the Ruby side is completely broken, `setup-homebrew` should work similarly to get a functional version.

https://github.com/Homebrew/homebrew-core/actions/runs/4920922528/jobs/8790636214#step:2:37
(in this case, the bad version was from a Homebrew/brew CI run - not something that was merged)

In the longer term, we should perhaps implement `brew --repo <tap>` in shell.