### PR TITLE
Add gh-try-download action

### DIFF
--- a/gh-try-download/action.yml
+++ b/gh-try-download/action.yml
@@ -1,0 +1,62 @@
+name: "`gh run download` with retries"
+description: Runs `gh run download` with retries after failure
+inputs:
+  artifact-name:
+    description: Name(s) of artifact(s) to download
+    required: true
+  workflow-id:
+    description: ID of workflow run to download from
+    required: true
+  repository:
+    description: "Repository to download artifacts from. (default: `GITHUB_REPOSITORY`)"
+    required: false
+    default: ${{ github.repository }}
+  token:
+    description: "Authentication token for `gh`. (default: `GITHUB_TOKEN`)"
+    required: false
+    default: ${{ github.token }}
+  max-tries:
+    description: "Maximum number of tries. (default: 5)"
+    required: false
+    default: 5
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        GH_REPO: ${{ inputs.repository }}
+        GH_NO_UPDATE_NOTIFIER: 1
+        GH_PROMPT_DISABLED: 1
+        WORKFLOW_ID: ${{ inputs.workflow-id }}
+        TRIES: ${{ inputs.max-tries }}
+        ARTIFACT: ${{ inputs.artifact-name }}
+      run: |
+        attempt=0
+        max_attempts="$TRIES"
+        timeout=1
+
+        while [[ "$attempt" -lt "$max_attempts" ]]
+        do
+          attempt=$(( attempt + 1 ))
+
+          if gh run download --name "$ARTIFACT" "$WORKFLOW_ID"
+          then
+            success=1
+          fi
+
+          if [[ -n "$success" ]] || [[ "$attempt" -eq "$max_attempts" ]]
+          then
+            break
+          fi
+
+          echo "::notice ::Download failed. Trying again in ${timeout}s..."
+          sleep "$timeout"
+          timeout=$(( timeout * 3 ))
+        done
+
+        if [[ -z "$success" ]]
+        then
+          echo "::error ::Download failed!"
+          exit 1
+        fi


### PR DESCRIPTION
This will allow us to try `gh run download` multiple times before giving
up, and will help fix some of the automerge workflow errors we have in
Homebrew/core.
