### PR TITLE
setup-homebrew: propagate `debug` to `brew`

### DIFF
--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -19,15 +19,6 @@ runs:
       id: setup-homebrew
       uses: Homebrew/actions/setup-homebrew@master
 
-    - name: Enable debug mode
-      if: runner.debug
-      run: |
-        {
-          echo 'HOMEBREW_DEBUG=1'
-          echo 'HOMEBREW_VERBOSE=1'
-        } >> "${GITHUB_ENV}"
-      shell: bash
-
     - run: brew test-bot --only-cleanup-before
       if: fromJson(inputs.cleanup)
       shell: /bin/bash -e {0}

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -98,6 +98,12 @@ else
     echo "$HOMEBREW_PREFIX/bin" >> "$GITHUB_PATH"
 fi
 
+# This needs to be done after permission fixes above.
+if [[ "${DEBUG}" == 'true' ]]; then
+  echo HOMEBREW_DEBUG=1 >> "$GITHUB_ENV"
+  echo HOMEBREW_VERBOSE=1 >> "$GITHUB_ENV"
+fi
+
 # Use an access token to checkout (private repositories)
 if [[ -n "${TOKEN}" ]]; then
     base64_token=$(echo -n "x-access-token:${TOKEN}" | base64)


### PR DESCRIPTION
This makes the `runner.debug` setting also make `brew` produce
verbose/debug output (unless the debug input is overridden).
