### PR TITLE
pre-build: use only `actions/cache/restore`

### DIFF
--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -38,7 +38,7 @@ runs:
 
     - name: Cache Homebrew Bundler RubyGems
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
         path: ${{ steps.set-up-homebrew.outputs.gems-path }}
         key: ${{ env.cache_key_prefix }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}


### PR DESCRIPTION
PR branches have isolated caches, so storing a cache for a PR branch
isn't very useful.

We can generate a cache on `master` first and then restore from that
cache.
