### PR TITLE
setup-homebrew: fix HOMEBREW_NO_INSTALL_FROM_API case

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -205,7 +205,7 @@ else
         git_retry -C "$HOMEBREW_CORE_REPOSITORY" fetch --force origin
         git -C "$HOMEBREW_CORE_REPOSITORY" remote set-head origin --auto
         git -C "$HOMEBREW_CORE_REPOSITORY" checkout --force -B master origin/HEAD
-    elif [[ -n "${HOMEBREW_NO_INSTALL_FROM_API-}" ]]; then
+    elif [[ -n "${HOMEBREW_NO_INSTALL_FROM_API-}" ]] && [[ ! -d "${HOMEBREW_CORE_REPOSITORY}" ]]; then
         ohai "Fetching Homebrew/core..."
         git_retry clone https://github.com/Homebrew/homebrew-core "${HOMEBREW_CORE_REPOSITORY}"
     fi


### PR DESCRIPTION
Edge case I missed because the conditions that invoke `else` changed.