### PR TITLE
setup-homebrew: update tweaks.

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
+          core: false
+          cask: false
           test-bot: false
 
       - uses: actions/checkout@v3

--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -18,6 +18,10 @@ runs:
     - name: Set up Homebrew
       id: set-up-homebrew
       uses: Homebrew/actions/setup-homebrew@master
+      with:
+        core: true
+        cask: false
+        test-bot: true
 
     - run: brew test-bot --only-cleanup-before
       if: fromJson(inputs.cleanup)

--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -8,15 +8,15 @@ inputs:
   core:
     description: Update the `homebrew/core` tap.
     required: false
-    default: true
+    default: false
   cask:
     description: Update the `homebrew/cask` tap.
     required: false
-    default: true
+    default: false
   test-bot:
     description: Install the `homebrew/test-bot` tap.
     required: false
-    default: true
+    default: auto
   debug:
     description: Show debugging output
     required: false
@@ -24,7 +24,7 @@ inputs:
   token:
     description: Token to be used for GitHub authentication (if using private repositories). This token will persist through other steps for the duration of the job.
     required: false
-    default: ''
+    default: ""
 outputs:
   repository-path:
     description: Path to where the repository has been checked out (if applicable)


### PR DESCRIPTION
- don't update core/cask/test-bot by default
- unset HOMEBREW_NO_INSTALL_FROM_API (which GitHub Actions sets by default
- use `brew update` to download formula/cask files

---

If this is ✅: we'll need to audit our usage of this action to ensure they are configured correctly to allow this change but it should reduce load on GitHub, failures seen by us and our users and better test the default Homebrew setup.