### PR TITLE
setup-homebrew: move autoupdate, unset bootsnap

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -142,6 +142,16 @@ else
     fi
 fi
 
+# Run `brew update` once to e.g. download formula/cask JSON files.
+(
+    ohai "brew update --auto"
+    # Unset these to ensure homebrew/core and homebrew/cask are not updated (again)
+    unset HOMEBREW_NO_INSTALL_FROM_API HOMEBREW_DEVELOPER HOMEBREW_DEV_CMD_RUN
+    unset HOMEBREW_UPDATE_CORE_TAP HOMEBREW_UPDATE_CASK_TAP
+    unset HOMEBREW_BOOTSNAP # so we don't install bundler gems here before any caching
+    brew update --auto
+)
+
 # Setup Homebrew Bundler RubyGems cache
 GEMS_PATH="$HOMEBREW_REPOSITORY/Library/Homebrew/vendor/bundle/ruby/"
 GEMS_HASH="$(shasum -a 256 "$HOMEBREW_REPOSITORY/Library/Homebrew/Gemfile.lock" | cut -f1 -d' ')"
@@ -255,14 +265,6 @@ if [[ "${TEST_BOT}" == "true" ]] || [[ "${TEST_BOT}" == "auto" && -n "${HOMEBREW
         git_retry clone https://github.com/Homebrew/homebrew-test-bot "$HOMEBREW_TEST_BOT_REPOSITORY"
     fi
 fi
-
-# Run `brew update` once to e.g. download formula/cask JSON files.
-(
-    # Unset these to ensure homebrew/core and homebrew/cask are not updated (again)
-    unset HOMEBREW_NO_INSTALL_FROM_API HOMEBREW_DEVELOPER HOMEBREW_DEV_CMD_RUN
-    unset HOMEBREW_UPDATE_CORE_TAP HOMEBREW_UPDATE_CASK_TAP
-    brew update --auto
-)
 
 # Setup Linux permissions
 if [[ "$RUNNER_OS" = "Linux" ]] && [[ -z "${HOMEBREW_IN_CONTAINER-}" ]] && [[ -z "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-}" ]]; then


### PR DESCRIPTION
* Move autoupdate earlier just to make sure we don't undo what we do for third-party taps
* Unset `HOMEBREW_BOOTSNAP` so we don't install bundler gems here before any caching can kick in