### PR TITLE
setup-homebrew/main: use correct auto-update flag.

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -154,12 +154,12 @@ fi
 if [[ "$GITHUB_REPOSITORY" != "Homebrew/formulae.brew.sh" ]]; then
     # Run `brew update` once to e.g. download formula/cask JSON files.
     (
-        ohai "brew update --auto"
+        ohai "brew update --auto-update"
         # Unset these to ensure homebrew/core and homebrew/cask are not updated (again)
         unset HOMEBREW_NO_INSTALL_FROM_API HOMEBREW_DEVELOPER HOMEBREW_DEV_CMD_RUN
         unset HOMEBREW_UPDATE_CORE_TAP HOMEBREW_UPDATE_CASK_TAP
         unset HOMEBREW_BOOTSNAP # so we don't install bundler gems here before any caching
-        HOMEBREW_UPDATE_SKIP_BREW=1 retry brew update --auto
+        HOMEBREW_UPDATE_SKIP_BREW=1 retry brew update --auto-update --verbose
     )
 fi
 


### PR DESCRIPTION
This existing one was just doing `brew update`.