### PR TITLE
setup-homebrew/main: remove unnecessary unset variables.

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -157,7 +157,6 @@ if [[ "$GITHUB_REPOSITORY" != "Homebrew/formulae.brew.sh" ]]; then
         ohai "brew update --auto-update"
         # Unset these to ensure homebrew/core and homebrew/cask are not updated (again)
         unset HOMEBREW_NO_INSTALL_FROM_API HOMEBREW_DEVELOPER HOMEBREW_DEV_CMD_RUN
-        unset HOMEBREW_UPDATE_CORE_TAP HOMEBREW_UPDATE_CASK_TAP
         unset HOMEBREW_BOOTSNAP # so we don't install bundler gems here before any caching
         HOMEBREW_UPDATE_SKIP_BREW=1 retry brew update --auto-update --verbose
     )


### PR DESCRIPTION
These are better handled in `brew.sh` now and the names have changed.