### PR TITLE
feat: bump runtime to node 20

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -32,7 +32,7 @@ jobs:
           cask: false
           test-bot: false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up actionlint
         run: |

--- a/.github/workflows/brew-script.yml
+++ b/.github/workflows/brew-script.yml
@@ -15,7 +15,7 @@ jobs:
       HOMEBREW_FILENAME: ".revision"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure PATH
         run: echo "/home/linuxbrew/.linuxbrew/bin" >> "${GITHUB_PATH}"

--- a/.github/workflows/bump-formulae.yml
+++ b/.github/workflows/bump-formulae.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Update core
         run: brew update-reset "$(brew --repo Homebrew/core)"

--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cancel
         uses: ./cancel-previous-runs

--- a/.github/workflows/check-commit-format.yml
+++ b/.github/workflows/check-commit-format.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test
         uses: ./check-commit-format/

--- a/.github/workflows/count-bottles.yml
+++ b/.github/workflows/count-bottles.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check scripts
         run: shellcheck --enable=all count-bottles/*.sh

--- a/.github/workflows/create-gcloud-instance.yml
+++ b/.github/workflows/create-gcloud-instance.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check scripts
         run: shellcheck --enable=all create-gcloud-instance/*.sh

--- a/.github/workflows/dismiss-approvals.yml
+++ b/.github/workflows/dismiss-approvals.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Approve
         env:

--- a/.github/workflows/download-artifact-download.yml
+++ b/.github/workflows/download-artifact-download.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Wait
         run: sleep 60s

--- a/.github/workflows/git-try-push.yml
+++ b/.github/workflows/git-try-push.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/git-user-config.yml
+++ b/.github/workflows/git-user-config.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Config
         id: config

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test JSON
         uses: ./label-pull-requests/

--- a/.github/workflows/post-comment.yml
+++ b/.github/workflows/post-comment.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test
         uses: ./post-comment/

--- a/.github/workflows/post-review.yml
+++ b/.github/workflows/post-review.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test
         uses: ./post-review/

--- a/.github/workflows/review-cask-pr.yml
+++ b/.github/workflows/review-cask-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/setup-commit-signing.yml
+++ b/.github/workflows/setup-commit-signing.yml
@@ -23,7 +23,7 @@ jobs:
     container: ${{ matrix.container }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure git user
         uses: ./git-user-config/

--- a/.github/workflows/vendor-node-modules.yml
+++ b/.github/workflows/vendor-node-modules.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: actions/setup-node@v3

--- a/.github/workflows/wait-for-idle-runner.yml
+++ b/.github/workflows/wait-for-idle-runner.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check scripts
         run: node --check wait-for-idle-runner/main.js

--- a/cancel-previous-runs/action.yml
+++ b/cancel-previous-runs/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: false
     default: ${{github.token}}
 runs:
-  using: node16
+  using: node20
   main: main.js

--- a/check-commit-format/action.yml
+++ b/check-commit-format/action.yml
@@ -22,5 +22,5 @@ inputs:
     required: false
     default: CI-published-bottle-commits
 runs:
-  using: node16
+  using: node20
   main: main.js

--- a/dismiss-approvals/action.yml
+++ b/dismiss-approvals/action.yml
@@ -16,5 +16,5 @@ inputs:
     description: Dismissal message
     required: true
 runs:
-  using: node16
+  using: node20
   main: main.js

--- a/download-artifact/action.yml
+++ b/download-artifact/action.yml
@@ -30,5 +30,5 @@ inputs:
     required: false
     default: "./"
 runs:
-  using: node16
+  using: node20
   main: main.js

--- a/git-try-push/action.yml
+++ b/git-try-push/action.yml
@@ -36,5 +36,5 @@ inputs:
     description: Whether to force push without lease (requires force)
     required: false
 runs:
-  using: node16
+  using: node20
   main: main.js

--- a/git-user-config/action.yml
+++ b/git-user-config/action.yml
@@ -19,5 +19,5 @@ outputs:
   email:
     description: Configured git user's email
 runs:
-  using: node16
+  using: node20
   main: main.js

--- a/label-pull-requests/action.yml
+++ b/label-pull-requests/action.yml
@@ -77,5 +77,5 @@ inputs:
 
     required: true
 runs:
-  using: node16
+  using: node20
   main: main.js

--- a/post-comment/action.yml
+++ b/post-comment/action.yml
@@ -22,5 +22,5 @@ inputs:
     description: Bot's username
     required: false
 runs:
-  using: node16
+  using: node20
   main: main.js

--- a/post-review/action.yml
+++ b/post-review/action.yml
@@ -20,5 +20,5 @@ inputs:
     description: Review content
     required: false
 runs:
-  using: node16
+  using: node20
   main: main.js

--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -33,6 +33,6 @@ outputs:
   gems-hash:
     description: Homebrew's Ruby Gemfile.lock sha256sum
 runs:
-  using: node16
+  using: node20
   main: main.mjs
   post: post.mjs

--- a/wait-for-idle-runner/action.yml
+++ b/wait-for-idle-runner/action.yml
@@ -21,5 +21,5 @@ outputs:
   runner-idle:
     description: Runner is idle (true/false)
 runs:
-  using: node16
+  using: node20
   main: main.js


### PR DESCRIPTION
Node12 was deleted from runner. Node20 was added to Actions Runner on v2.308.0.
Node16 has en end of life on 11 Sep 2023.

This PR updates the default runtime to node20, rather then node16

---

also bump checkout action to v4