### PR TITLE
check-commit-format: fail the status check when autosquash is needed

### DIFF
--- a/check-commit-format/main.js
+++ b/check-commit-format/main.js
@@ -81,7 +81,8 @@ async function main() {
                 // We've already modified this file, or the commit subject doesn't start with the formula name.
                 if (files_touched.includes(file.filename) || !commit_subject.startsWith(formula)) {
                     autosquash = true
-                    message = "Pull request will be replaced."
+                    commit_state = "failure"
+                    message = "Please follow the commit style guidelines, or this pull request will be replaced."
                 }
                 files_touched.push(file.filename)
             } else if (file.filename.startsWith("Casks/")) {


### PR DESCRIPTION
Contributors do not generally seem to understand the implication of the `autosquash` label, and we often need to ask them to squash the commits, do the work for them, or let the PR be replaced (which is less ideal as it requires another full round of CI run). Let's instead fail this check and make the status check message more explicit, hoping this will draw more attention.
