### PR TITLE
setup-homebrew: temporarily revert to node 16

### DIFF
--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -33,6 +33,6 @@ outputs:
   gems-hash:
     description: Homebrew's Ruby Gemfile.lock sha256sum
 runs:
-  using: node20
+  using: node16 # Bump to node 20 once portable-ruby CI supports it
   main: main.mjs
   post: post.mjs


### PR DESCRIPTION
This is breaking portable Ruby CI and is blocking me from making any progress on Ruby 3 - and I would like to do so this weekend.

The problem is Node 20 binaries shipped with the runner only work on macOS 10.15 and later and our 10.11-cross image runs 10.13 (the minimum requirement for Node 16).

We'll likely need to do any one of the following:
* Move 10.11-cross to be a 10.15 image (or later) with the 10.11 SDK. While I cannot yet guarantee this works, I haven't tried it yet so it might well work fine. Depends on compiler compatibility.
* Build our own Node, save it to the 10.11-cross image and use that instead of the prebuilt GitHub uses.
* Drop support for 10.11-10.14 entirely (or potentially less if we want a, e.g., 10.14-cross on 10.15). This will require a minor version bump of brew.

All of these will take some time, but we do have a little bit. Node 16 will work until spring 2024, with warnings appearing on 23rd October. We can decide a path now and implement that over the coming days/weeks.
