### PR TITLE
workflows/setup-commit-signing: exclude dependabot.

### DIFF
--- a/.github/workflows/setup-commit-signing.yml
+++ b/.github/workflows/setup-commit-signing.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   commit-signing:
-    if: github.repository_owner == 'Homebrew'
+    if: github.repository_owner == 'Homebrew' && github.actor != 'dependabot[bot]'
     strategy:
       matrix:
         container:


### PR DESCRIPTION
It doesn't have the necessary secrets set so will always fail.