### PR TITLE
label-pull-requests: add `allow_any_match`

### DIFF
--- a/label-pull-requests/README.md
+++ b/label-pull-requests/README.md
@@ -18,7 +18,8 @@ Will remove labels from a pull request that no longer apply.
           {
               "label": "new formula",
               "status": "added",
-              "path": "Formula/.+"
+              "path": "Formula/.+",
+              "allow_any_match": true
           },
           {
               "label": "bottle unneeded",
@@ -65,6 +66,7 @@ Will remove labels from a pull request that no longer apply.
       - label: new formula
         status: added
         path: Formula/.+
+        allow_any_match: true
 
       - label: bottle unneeded
         content: bottle :unneeded

--- a/label-pull-requests/main.js
+++ b/label-pull-requests/main.js
@@ -132,6 +132,11 @@ async function main() {
             const constraint = constraintAndMatchingFiles[0]
             const matchingFiles = constraintAndMatchingFiles[1]
 
+            // Continue if constraint allows any PR file to match
+            if (constraint.allow_any_match) {
+                continue
+            }
+
             if (matchingFiles.length == files.data.length) {
                 continue
             }


### PR DESCRIPTION
Not sure about naming.

Currently need a way to correctly label PRs when they modify more than one file (e.g. alias, multiple synced formulae, etc).

Particularly for some CI-impacting labels which can be problematic if missing, e.g. `long build` & `CI-build-dependents-from-source` for `ghc` always missing on next major/minor release.