### PR TITLE
Generate build provenance before upload.

### DIFF
--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -86,9 +86,10 @@ runs:
       shell: bash
 
     - name: generate build provenance
-        uses: github-early-access/generate-build-provenance@main
-        with:
-          subject-path: '${{ inputs.bottles-directory }}/*.tar.gz'
+      if: always() && fromJson(inputs.upload-bottles) && (steps.bottles.outputs.count > 0 || steps.bottles.outputs.skipped > 0)
+      uses: github-early-access/generate-build-provenance@main
+      with:
+        subject-path: '${{ inputs.bottles-directory }}/*.tar.gz'
 
     - name: Upload bottles
       if: always() && fromJson(inputs.upload-bottles) && (steps.bottles.outputs.count > 0 || steps.bottles.outputs.skipped > 0)

--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -85,6 +85,11 @@ runs:
       working-directory: ${{ inputs.bottles-directory }}
       shell: bash
 
+    - name: generate build provenance
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-path: '${{ inputs.bottles-directory }}/*.tar.gz'
+
     - name: Upload bottles
       if: always() && fromJson(inputs.upload-bottles) && (steps.bottles.outputs.count > 0 || steps.bottles.outputs.skipped > 0)
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR adds a step in the `post-build` action that generates build providence for bottles that are built and will be uploaded. This is part of the larger effort to add verifiable build provenance for Homebrew bottles.

This is currently a draft and needs some further testing. Any feedback in the meantime is encouraged! Please let me know if there is a problem with signing post-build and before upload, or if there is a better place for this. My work so far leads me to believe this is the simplest place, but I'm certain others have more context that I am lacking.