### PR TITLE
actions: use `/bin/bash`

### DIFF
--- a/count-bottles/action.yml
+++ b/count-bottles/action.yml
@@ -27,5 +27,5 @@ runs:
   steps:
     - run: ./count.sh '${{ inputs.working-directory }}' '${{ inputs.debug }}'
       working-directory: ${{ github.action_path }}
-      shell: bash
+      shell: /bin/bash -euo pipefail {0}
       id: count

--- a/failures-summary-and-bottle-result/action.yml
+++ b/failures-summary-and-bottle-result/action.yml
@@ -40,4 +40,4 @@ runs:
         "${{ inputs.collapse }}" && printf '\n</p>\n</details>\n' >> "$GITHUB_STEP_SUMMARY"
 
         rm "$full_result_path"
-      shell: bash
+      shell: /bin/bash -euo pipefail {0}

--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -83,7 +83,7 @@ runs:
         rm -rvf logs home failed artifact-cache
         rm -rvf tested-dependents-*.txt
       working-directory: ${{ inputs.bottles-directory }}
-      shell: bash
+      shell: /bin/bash -euo pipefail {0}
 
     - name: Upload bottles
       if: always() && fromJson(inputs.upload-bottles) && (steps.bottles.outputs.count > 0 || steps.bottles.outputs.skipped > 0)
@@ -97,6 +97,6 @@ runs:
       run: |
         brew test-bot --only-cleanup-after
         rm -rvf "${BOTTLES_DIR:?}"
-      shell: /bin/bash -e {0}
+      shell: /bin/bash -euo pipefail {0}
       env:
         BOTTLES_DIR: ${{ inputs.bottles-directory }}

--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -25,10 +25,10 @@ runs:
 
     - run: brew test-bot --only-cleanup-before
       if: fromJson(inputs.cleanup)
-      shell: /bin/bash -e {0}
+      shell: /bin/bash -euo pipefail {0}
 
     - name: Set up RubyGems cache
-      shell: bash
+      shell: /bin/bash -euo pipefail {0}
       run: |
         cache_key_prefix="${{ runner.os }}"
         if [[ "${{ runner.os }}" = macOS ]]
@@ -55,13 +55,13 @@ runs:
         HOMEBREW_NO_COLOR=1 brew test-bot --only-setup | tee -a "${GITHUB_STEP_SUMMARY}"
         printf '```\n' >> "${GITHUB_STEP_SUMMARY}"
         printf '\n</p>\n</details>\n' >> "$GITHUB_STEP_SUMMARY"
-      shell: bash
+      shell: /bin/bash -euo pipefail {0}
 
     - name: Set up bottles directory
       run: |
         rm -rvf "${BOTTLES_DIR:?}"
         mkdir "${BOTTLES_DIR:?}"
-      shell: bash
+      shell: /bin/bash -euo pipefail {0}
       env:
         BOTTLES_DIR: ${{ inputs.bottles-directory }}
 

--- a/setup-homebrew/main.mjs
+++ b/setup-homebrew/main.mjs
@@ -3,7 +3,7 @@ import core from "@actions/core"
 
 // GitHub Actions does not support shell `post` actions and thus requires a JS wrapper.
 try {
-  await exec("bash", [
+  await exec("/bin/bash", [
     new URL("./main.sh", import.meta.url).pathname,
     core.getInput("core"),
     core.getInput("cask"),

--- a/setup-homebrew/post.mjs
+++ b/setup-homebrew/post.mjs
@@ -3,7 +3,7 @@ import core from "@actions/core"
 
 // GitHub Actions does not support shell `post` actions and thus requires a JS wrapper.
 try {
-  await exec("bash", [
+  await exec("/bin/bash", [
     new URL("./post.sh", import.meta.url).pathname,
     core.getInput("debug")
   ])


### PR DESCRIPTION
When there is a broken `bash` in `PATH`, some actions may fail as in Homebrew/homebrew-core#162819. (See [this job](https://github.com/Homebrew/homebrew-core/actions/runs/7916916851/job/21612022470?pr=162819).) Let's modify those actions to use `/bin/bash` instead of an arbitrary `bash` from `PATH`; `brew` requires and always runs on `/bin/bash` anyway.
