### PR TITLE
count-bottles: use `/bin/bash`

### DIFF
--- a/count-bottles/count.sh
+++ b/count-bottles/count.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 WORKING_DIRECTORY="$1"
 DEBUG="$2"


### PR DESCRIPTION
One more fix like #488.
