### PR TITLE
bump-packages: use `--no-fork` switch on our taps

### DIFF
--- a/bump-packages/action.yml
+++ b/bump-packages/action.yml
@@ -19,15 +19,25 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: brew bump --open-pr --formulae ${{ inputs.formulae }}
+    - run: |
+        if [[ "${GITHUB_REPOSITORY_OWNER}" == 'Homebrew' ]]; then
+          brew bump --no-fork --open-pr --formulae ${{ inputs.formulae }}
+        else
+          brew bump --open-pr --formulae ${{ inputs.formulae }}
+        fi
+      shell: bash
       if: inputs.formulae != ''
-      shell: sh
       env:
         HOMEBREW_DEVELOPER: "1"
-        HOMEBREW_GITHUB_API_TOKEN: ${{inputs.token}}
-    - run: brew bump --open-pr --casks ${{ inputs.casks }}
-      if: inputs.casks != ''
-      shell: sh
+        HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}
+    - run: |
+        if [[ "${GITHUB_REPOSITORY_OWNER}" == 'Homebrew' ]]; then
+          brew bump --no-fork --open-pr --cask ${{ inputs.cask}}
+        else
+          brew bump --open-pr --cask ${{ inputs.cask }}
+        fi
+      shell: bash
+      if: inputs.cask != ''
       env:
         HOMEBREW_DEVELOPER: "1"
-        HOMEBREW_GITHUB_API_TOKEN: ${{inputs.token}}
+        HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
This PR switches the behavior of the `bump-packages` Action to use the new `--no-fork` switch added in https://github.com/Homebrew/brew/pull/16740. As I called out in that PR:
>We can use this for BrewTestBot's autobump PR's. This will reduce the thousands of stale branches in the BrewTestBot forks (which I still plan to deal with).

Since the repo's branches get deleted after merging, this will save us the headache of cleaning up BrewTestBot's forks and allow us to see the branches more easily so they can be prioritized.