### PR TITLE
Revert "bump-packages: use `--no-fork` switch on our taps"

### DIFF
--- a/bump-packages/action.yml
+++ b/bump-packages/action.yml
@@ -19,25 +19,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: |
-        if [[ "${GITHUB_REPOSITORY_OWNER}" == 'Homebrew' ]]; then
-          brew bump --no-fork --open-pr --formulae ${{ inputs.formulae }}
-        else
-          brew bump --open-pr --formulae ${{ inputs.formulae }}
-        fi
-      shell: bash
+    - run: brew bump --open-pr --formulae ${{ inputs.formulae }}
       if: inputs.formulae != ''
+      shell: sh
       env:
         HOMEBREW_DEVELOPER: "1"
-        HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}
-    - run: |
-        if [[ "${GITHUB_REPOSITORY_OWNER}" == 'Homebrew' ]]; then
-          brew bump --no-fork --open-pr --casks ${{ inputs.casks }}
-        else
-          brew bump --open-pr --casks ${{ inputs.casks }}
-        fi
-      shell: bash
+        HOMEBREW_GITHUB_API_TOKEN: ${{inputs.token}}
+    - run: brew bump --open-pr --casks ${{ inputs.casks }}
       if: inputs.casks != ''
+      shell: sh
       env:
         HOMEBREW_DEVELOPER: "1"
-        HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}
+        HOMEBREW_GITHUB_API_TOKEN: ${{inputs.token}}


### PR DESCRIPTION
This needs some changes on the `brew` side to handle this, so reverting until that can be addressed.