### PR TITLE
limit-pull-requests: new action

### DIFF
--- a/limit-pull-requests/README.md
+++ b/limit-pull-requests/README.md
@@ -20,6 +20,9 @@ by a user.
   with:
     except-users: |
       BrewTestBot
+    # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+    except-author-associations: |
+      MEMBER
     comment-limit: 10
     comment: >
       You already have 10 pull requests open. Please consider working on getting

--- a/limit-pull-requests/README.md
+++ b/limit-pull-requests/README.md
@@ -17,11 +17,12 @@ An action that limits the number of pull requests opened by a user.
 ```yaml
 - uses: Homebrew/actions/limit-pull-requests@master
   with:
-    limit: 10
     except-users: |
       BrewTestBot
+    comment-limit: 10
     comment: >
       You already have 10 pull requests open. Please consider working on getting
       the existing ones merged before opening new ones. Thanks!
-    close: false
+    close-limit: 50
+    close: true
 ```

--- a/limit-pull-requests/README.md
+++ b/limit-pull-requests/README.md
@@ -1,0 +1,27 @@
+# Limit Pull Requests GitHub Action
+
+An action that limits the number of pull requests opened by a user.
+
+## Prerequisites
+
+- [GitHub CLI (`gh`)](https://github.com/cli/cli) needs to be installed.
+- These permissions need to be set:
+  ```yaml
+  permissions:
+    contents: read
+    pull-requests: write
+  ```
+
+## Usage
+
+```yaml
+- uses: Homebrew/actions/limit-pull-requests@master
+  with:
+    limit: 10
+    except-users: |
+      BrewTestBot
+    comment: >
+      You already have 10 pull requests open. Please consider working on getting
+      the existing ones merged before opening new ones. Thanks!
+    close: false
+```

--- a/limit-pull-requests/README.md
+++ b/limit-pull-requests/README.md
@@ -1,6 +1,7 @@
 # Limit Pull Requests GitHub Action
 
-An action that limits the number of pull requests opened by a user.
+An action that limits the number of open pull requests to the repository created
+by a user.
 
 ## Prerequisites
 

--- a/limit-pull-requests/action.yml
+++ b/limit-pull-requests/action.yml
@@ -1,0 +1,82 @@
+name: Limit pull requests
+description: Limit the number of pull requests to the repository created by a user
+author: ZhongRuoyu
+branding:
+  icon: alert-triangle
+  color: yellow
+
+inputs:
+  token:
+    description: GitHub token
+    required: false
+    default: ${{ github.token }}
+  limit:
+    description: The maximum number of pull requests allowed
+    required: true
+    default: "10"
+  except-users:
+    description: The users exempted from the limit, one per line
+    required: false
+  # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+  except-author-associations:
+    description: The author associations exempted from the limit, one per line
+    required: false
+  comment:
+    description: The comment to post when the limit is reached
+    required: false
+  close:
+    description: Whether to close the pull request when the limit is reached
+    required: true
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Check the number of pull requests
+      id: count-pull-requests
+      run: |
+        # If the user is exempted, assume they have no pull requests.
+        if grep -Fqx '${{ github.actor }}' <<<'${{ inputs.except-users }}'; then
+          echo "::notice::@${{ github.actor }} is exempted from the limit."
+          echo "count=0" >>"$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if grep -Fqx '${{ github.event.pull_request.author_association }}' <<<'${{ inputs.except-author-associations }}'; then
+          echo "::notice::@{{ github.actor }} is a ${{ github.event.pull_request.author_association }} exempted from the limit."
+          echo "count=0" >>"$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        count="$(
+          gh pr list \
+            --state=open \
+            --author='${{ github.actor }}' \
+            --json=number \
+            --jq=length
+        )"
+        echo "::notice::Open pull requests by @${{ github.actor }}: $count."
+        echo "count=$count" >>"$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      shell: bash
+
+    - name: Comment on pull request
+      if: >
+        steps.count-pull-requests.outputs.count > inputs.limit &&
+        inputs.comment != ''
+      run: |
+        gh pr comment '${{ github.event.pull_request.number }}' \
+          --body='${{ inputs.comment }}'
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      shell: bash
+
+    - name: Close pull request
+      if: >
+        steps.count-pull-requests.outputs.count > inputs.limit &&
+        inputs.close == 'true'
+      run: |
+        gh pr close '${{ github.event.pull_request.number }}'
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      shell: bash

--- a/limit-pull-requests/action.yml
+++ b/limit-pull-requests/action.yml
@@ -11,12 +11,6 @@ inputs:
     description: GitHub token
     required: false
     default: ${{ github.token }}
-  comment-limit:
-    description: >
-      Post the comment when the user's number of open pull requests exceeds this
-      number and `comment` is not empty
-    required: true
-    default: "10"
   except-users:
     description: The users exempted from the limit, one per line
     required: false
@@ -24,6 +18,12 @@ inputs:
   except-author-associations:
     description: The author associations exempted from the limit, one per line
     required: false
+  comment-limit:
+    description: >
+      Post the comment when the user's number of open pull requests exceeds this
+      number and `comment` is not empty
+    required: true
+    default: "10"
   comment:
     description: The comment to post when the limit is reached
     required: false

--- a/limit-pull-requests/action.yml
+++ b/limit-pull-requests/action.yml
@@ -10,8 +10,10 @@ inputs:
     description: GitHub token
     required: false
     default: ${{ github.token }}
-  limit:
-    description: The maximum number of pull requests allowed
+  comment-limit:
+    description: >
+      Post the comment when the user's number of open pull requests exceeds this
+      number and `comment` is not empty
     required: true
     default: "10"
   except-users:
@@ -24,6 +26,12 @@ inputs:
   comment:
     description: The comment to post when the limit is reached
     required: false
+  close-limit:
+    description: >
+      Close the pull request when the user's number of open pull requests
+      exceeds this number and `close` is set to `true`
+    required: true
+    default: "50"
   close:
     description: Whether to close the pull request when the limit is reached
     required: true
@@ -62,7 +70,7 @@ runs:
 
     - name: Comment on pull request
       if: >
-        steps.count-pull-requests.outputs.count > inputs.limit &&
+        steps.count-pull-requests.outputs.count > inputs.comment-limit &&
         inputs.comment != ''
       run: |
         gh pr comment '${{ github.event.pull_request.number }}' \
@@ -73,7 +81,7 @@ runs:
 
     - name: Close pull request
       if: >
-        steps.count-pull-requests.outputs.count > inputs.limit &&
+        steps.count-pull-requests.outputs.count > inputs.close-limit &&
         inputs.close == 'true'
       run: |
         gh pr close '${{ github.event.pull_request.number }}'

--- a/limit-pull-requests/action.yml
+++ b/limit-pull-requests/action.yml
@@ -21,7 +21,7 @@ inputs:
   comment-limit:
     description: >
       Post the comment when the user's number of open pull requests exceeds this
-      number and `comment` is not empty
+      number and `comment` is not empty (maximum: 99)
     required: true
     default: "10"
   comment:
@@ -30,7 +30,7 @@ inputs:
   close-limit:
     description: >
       Close the pull request when the user's number of open pull requests
-      exceeds this number and `close` is set to `true`
+      exceeds this number and `close` is set to `true` (maximum: 99)
     required: true
     default: "50"
   close:
@@ -61,7 +61,8 @@ runs:
             --state=open \
             --author='${{ github.actor }}' \
             --json=number \
-            --jq=length
+            --jq=length \
+            --limit=100
         )"
         echo "::notice::Open pull requests by @${{ github.actor }}: $count."
         echo "count=$count" >>"$GITHUB_OUTPUT"

--- a/limit-pull-requests/action.yml
+++ b/limit-pull-requests/action.yml
@@ -1,5 +1,6 @@
 name: Limit pull requests
-description: Limit the number of pull requests to the repository created by a user
+description: >
+  Limit the number of open pull requests to the repository created by a user
 author: ZhongRuoyu
 branding:
   icon: alert-triangle

--- a/limit-pull-requests/action.yml
+++ b/limit-pull-requests/action.yml
@@ -45,12 +45,12 @@ runs:
       id: count-pull-requests
       run: |
         # If the user is exempted, assume they have no pull requests.
-        if grep -Fqx '${{ github.actor }}' <<<'${{ inputs.except-users }}'; then
+        if grep -Fiqx '${{ github.actor }}' <<<'${{ inputs.except-users }}'; then
           echo "::notice::@${{ github.actor }} is exempted from the limit."
           echo "count=0" >>"$GITHUB_OUTPUT"
           exit 0
         fi
-        if grep -Fqx '${{ github.event.pull_request.author_association }}' <<<'${{ inputs.except-author-associations }}'; then
+        if grep -Fiqx '${{ github.event.pull_request.author_association }}' <<<'${{ inputs.except-author-associations }}'; then
           echo "::notice::@{{ github.actor }} is a ${{ github.event.pull_request.author_association }} exempted from the limit."
           echo "count=0" >>"$GITHUB_OUTPUT"
           exit 0


### PR DESCRIPTION
Resolves #337.

Sample usage:

```yaml
- uses: Homebrew/actions/limit-pull-requests@master
  with:
    except-users: |
      BrewTestBot
    # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
    except-author-associations: |
      MEMBER
    comment-limit: 10
    comment: >
      You already have 10 pull requests open. Please consider working on getting
      the existing ones merged before opening new ones. Thanks!
    close-limit: 50
    close: true
```

An `except-author-associations` list is also accepted (e.g. `MEMBER`). We can discuss the exact rules when applying the action to the repos.
