### PR TITLE
limit-pull-requests: convert strings to numbers before comparing them

### DIFF
--- a/limit-pull-requests/action.yml
+++ b/limit-pull-requests/action.yml
@@ -77,7 +77,7 @@ runs:
 
     - name: Comment on pull request
       if: >
-        steps.count-pull-requests.outputs.count > inputs.comment-limit &&
+        fromJSON(steps.count-pull-requests.outputs.count) > fromJSON(inputs.comment-limit) &&
         inputs.comment != ''
       run: |
         gh pr comment '${{ github.event.pull_request.number }}' \
@@ -88,7 +88,7 @@ runs:
 
     - name: Close pull request
       if: >
-        steps.count-pull-requests.outputs.count > inputs.close-limit &&
+        fromJSON(steps.count-pull-requests.outputs.count) > fromJSON(inputs.close-limit) &&
         inputs.close == 'true'
       run: |
         gh pr close '${{ github.event.pull_request.number }}'


### PR DESCRIPTION
Otherwise we'd see funny results.

See https://docs.github.com/en/actions/learn-github-actions/expressions#operators.
