### PR TITLE
limit-pull-requests: better handle quotes in comment body

### DIFF
--- a/limit-pull-requests/action.yml
+++ b/limit-pull-requests/action.yml
@@ -81,9 +81,10 @@ runs:
         inputs.comment != ''
       run: |
         gh pr comment '${{ github.event.pull_request.number }}' \
-          --body='${{ inputs.comment }}'
+          --body="${COMMENT_BODY}"
       env:
         GH_TOKEN: ${{ inputs.token }}
+        COMMENT_BODY: ${{ inputs.comment }}
       shell: bash
 
     - name: Close pull request


### PR DESCRIPTION
By putting the comment body in an environment variable we can avoid having to escape quotes at all.
