### PR TITLE
limit-pull-requests: various improvements

### DIFF
--- a/limit-pull-requests/README.md
+++ b/limit-pull-requests/README.md
@@ -5,7 +5,8 @@ by a user.
 
 ## Prerequisites
 
-- [GitHub CLI (`gh`)](https://github.com/cli/cli) needs to be installed.
+- [GitHub CLI (`gh`)](https://github.com/cli/cli) and
+  [`jq`](https://jqlang.github.io/jq/) need to be installed.
 - These permissions need to be set:
   ```yaml
   permissions:
@@ -14,6 +15,8 @@ by a user.
   ```
 
 ## Usage
+
+This action should be used in a `pull_request_target` workflow.
 
 ```yaml
 - uses: Homebrew/actions/limit-pull-requests@master

--- a/limit-pull-requests/action.yml
+++ b/limit-pull-requests/action.yml
@@ -45,12 +45,12 @@ runs:
       id: count-pull-requests
       run: |
         # If the user is exempted, assume they have no pull requests.
-        if grep -Fiqx '${{ github.actor }}' <<<'${{ inputs.except-users }}'; then
+        if grep -Fiqx '${{ github.actor }}' <<<"$EXCEPT_USERS"; then
           echo "::notice::@${{ github.actor }} is exempted from the limit."
           echo "count=0" >>"$GITHUB_OUTPUT"
           exit 0
         fi
-        if grep -Fiqx '${{ github.event.pull_request.author_association }}' <<<'${{ inputs.except-author-associations }}'; then
+        if grep -Fiqx '${{ github.event.pull_request.author_association }}' <<<"$EXCEPT_AUTHOR_ASSOCIATIONS"; then
           echo "::notice::@{{ github.actor }} is a ${{ github.event.pull_request.author_association }} exempted from the limit."
           echo "count=0" >>"$GITHUB_OUTPUT"
           exit 0
@@ -69,10 +69,13 @@ runs:
               --arg USER '${{ github.actor }}' \
               'map(select(.user.login == $USER)) | length'
         )"
-        echo "::notice::Open pull requests by @${{ github.actor }}: $count."
+        echo "::notice::@${{ github.actor }} has $count open pull request(s)."
         echo "count=$count" >>"$GITHUB_OUTPUT"
       env:
+        GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ inputs.token }}
+        EXCEPT_USERS: ${{ inputs.except-users }}
+        EXCEPT_AUTHOR_ASSOCIATIONS: ${{ inputs.except-author-associations }}
       shell: bash
 
     - name: Comment on pull request
@@ -83,6 +86,7 @@ runs:
         gh pr comment '${{ github.event.pull_request.number }}' \
           --body="${COMMENT_BODY}"
       env:
+        GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ inputs.token }}
         COMMENT_BODY: ${{ inputs.comment }}
       shell: bash
@@ -94,5 +98,6 @@ runs:
       run: |
         gh pr close '${{ github.event.pull_request.number }}'
       env:
+        GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ inputs.token }}
       shell: bash


### PR DESCRIPTION
1. Avoid referencing inputs directly in shell scripts to prevent code injection.
2. Set `GH_REPO` to `${{ github.repository }}`. This is already set in [`triage.yml`](https://github.com/Homebrew/homebrew-core/blob/fd8564d9ba218798bf5dad00d47c5c4537ecb545/.github/workflows/triage.yml#L6) in `Homebrew/homebrew-core`, but if it's not and the repo is not checked out, `gh` will complain.
3. Update readme.
