### PR TITLE
Set `HOMEBREW_TEST_BOT_AUTOBUMP` in bump-packages

### DIFF
--- a/bump-packages/action.yml
+++ b/bump-packages/action.yml
@@ -29,6 +29,7 @@ runs:
       if: inputs.formulae != ''
       env:
         HOMEBREW_DEVELOPER: "1"
+        HOMEBREW_TEST_BOT_AUTOBUMP: "1"
         HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}
     - run: |
         if [[ "${GITHUB_REPOSITORY_OWNER}" == 'Homebrew' ]]; then
@@ -40,4 +41,5 @@ runs:
       if: inputs.casks != ''
       env:
         HOMEBREW_DEVELOPER: "1"
+        HOMEBREW_TEST_BOT_AUTOBUMP: "1"
         HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
This will unblock https://github.com/Homebrew/brew/pull/16750 by providing us with an environment variable that's only on when we're autobumping packages. In all other scenarios, we want people to get an error message if they try to bump one of the packages that gets regularly autobumped on CI.