### PR TITLE
setup-homebrew: support stable brew

### DIFF
--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: Token to be used for GitHub authentication (if using private repositories). This token will persist through other steps for the duration of the job.
     required: false
     default: ""
+  stable:
+    description: Use the latest stable `homebrew/brew` tag.
+    required: false
+    default: false
 outputs:
   repository-path:
     description: Path to where the repository has been checked out (if applicable)

--- a/setup-homebrew/main.mjs
+++ b/setup-homebrew/main.mjs
@@ -9,7 +9,8 @@ try {
     core.getInput("cask"),
     core.getInput("test-bot"),
     core.getInput("debug"),
-    core.getInput("token")
+    core.getInput("token"),
+    core.getInput("stable")
   ])
 } catch (error) {
   core.setFailed(error.message)

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -7,6 +7,7 @@ UPDATE_CASK="${2}"
 TEST_BOT="${3}"
 DEBUG="${4}"
 TOKEN="${5}"
+STABLE="${6}"
 
 if [[ "${DEBUG}" == "true" ]]; then
     set -x
@@ -148,6 +149,11 @@ else
     if [[ -n "${HOMEBREW_TAP_REPOSITORY-}" ]]; then
         echo "repository-path=$HOMEBREW_TAP_REPOSITORY" >>"$GITHUB_OUTPUT"
     fi
+fi
+if [[ "${STABLE}" == "true" ]]; then
+  echo HOMEBREW_UPDATE_TO_TAG=1 >>"$GITHUB_ENV"
+  latest_git_tag="$(git -C "$HOMEBREW_REPOSITORY" tag --list --sort="-version:refname" | head -n1)"
+  git -C "$HOMEBREW_REPOSITORY" checkout --force -B stable "refs/tags/${latest_git_tag}"
 fi
 
 # Skip autoupdate for formulae.brew.sh CI


### PR DESCRIPTION
Want to add a job to `homebrew/core` to check tap_syntax on stable tag.

Currently, we need to manually keep track of this to avoid accidentally introducing errors to users on stable tags.