### PR TITLE
pre/post-build: use Node 20 actions

### DIFF
--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Upload logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3-node20
       with:
         name: logs-${{ inputs.runner }}
         path: ${{ inputs.logs-directory }}
@@ -63,14 +63,14 @@ runs:
 
     - name: Upload failed bottles
       if: always() && steps.bottles.outputs.failures > 0
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3-node20
       with:
         name: bottles-${{ inputs.runner }}
         path: ${{ inputs.bottles-directory }}/failed
 
     - name: Upload list of successfully tested dependents
       if: always() && !fromJson(inputs.upload-bottles) && steps.bottles.outputs.dependents > 0
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3-node20
       with:
         name: dependents
         path: ${{ inputs.bottles-directory }}/tested-dependents-*.txt
@@ -87,7 +87,7 @@ runs:
 
     - name: Upload bottles
       if: always() && fromJson(inputs.upload-bottles) && (steps.bottles.outputs.count > 0 || steps.bottles.outputs.skipped > 0)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3-node20
       with:
         name: bottles
         path: ${{ inputs.bottles-directory }}

--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - name: Cache Homebrew Bundler RubyGems
       id: cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ${{ steps.set-up-homebrew.outputs.gems-path }}
         key: ${{ env.cache_key_prefix }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -67,7 +67,7 @@ runs:
 
     - name: Download bottles from GitHub Actions
       if: fromJson(inputs.download-bottles)
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v3-node20
       with:
         name: bottles
         path: ${{ inputs.bottles-directory }}


### PR DESCRIPTION
For the artifact actions we don't support v4 yet (#475), but there is now a v3-node20 we can use.