### PR TITLE
post-build: use `GITHUB_ACTION_PATH` instead of `github.action_path`

### DIFF
--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: Count bottles
       id: bottles
       if: always()
-      run: "${{ GITHUB_ACTION_PATH }}/count-bottles.sh ${{ inputs.debug }}"
+      run: "${ GITHUB_ACTION_PATH }/count-bottles.sh \"${{ inputs.debug }}\""
       working-directory: ${{ inputs.bottles-directory }}
       shell: /bin/bash -euo pipefail {0}
 

--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: Count bottles
       id: bottles
       if: always()
-      run: "${ GITHUB_ACTION_PATH }/count-bottles.sh \"${{ inputs.debug }}\""
+      run: '"${GITHUB_ACTION_PATH}/count-bottles.sh" "${{ inputs.debug }}"'
       working-directory: ${{ inputs.bottles-directory }}
       shell: /bin/bash -euo pipefail {0}
 

--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: Count bottles
       id: bottles
       if: always()
-      run: "${{ github.action_path }}/count-bottles.sh" "${{ inputs.debug }}"
+      run: "${{ GITHUB_ACTION_PATH }}/count-bottles.sh ${{ inputs.debug }}"
       working-directory: ${{ inputs.bottles-directory }}
       shell: /bin/bash -euo pipefail {0}
 


### PR DESCRIPTION
```
Error: Homebrew/actions/master/post-build/action.yml: (Line: 60, Col: 57, Idx: 1765) - (Line: 60, Col: 78, Idx: 1786): While parsing a block mapping, did not find expected key.
Error: System.ArgumentException: Unexpected type '' encountered while reading 'action manifest root'. The type 'MappingToken' was expected.
   at GitHub.DistributedTask.ObjectTemplating.Tokens.TemplateTokenExtensions.AssertMapping(TemplateToken value, String objectDescription)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Failed to load Homebrew/actions/master/post-build/action.yml
```

seen in https://github.com/Homebrew/homebrew-core/actions/runs/8577932249/job/23511213925?pr=168176