### PR TITLE
Fix usage for `bump-{formulae,packages}`

### DIFF
--- a/bump-formulae/README.md
+++ b/bump-formulae/README.md
@@ -20,7 +20,7 @@ If there are no outdated formulae, the Action will just exit.
     # Custom GitHub access token with only the 'public_repo' scope enabled
     token: ${{secrets.TOKEN}}
     # Bump only these formulae if outdated
-    formulae: |
+    formulae: >
       FORMULA-1
       FORMULA-2
       FORMULA-3

--- a/bump-packages/README.md
+++ b/bump-packages/README.md
@@ -18,13 +18,13 @@ If there are no outdated packages, the Action will just exit.
     # Custom GitHub access token with only the 'public_repo' scope enabled
     token: ${{secrets.TOKEN}}
     # Bump only these formulae if outdated
-    formulae: |
+    formulae: >
       FORMULA-1
       FORMULA-2
       FORMULA-3
       ...
     # Bump only these casks if outdated
-    casks: |
+    casks: >
       CASK-1
       CASK-2
       CASKS-3


### PR DESCRIPTION
`|` preserves newlines, so the current usage tries to run `FORMULA-2` as a command.

Expected expand results:

```sh
brew bump --open-pr --formulae FORMULA-1 FORMULA-2 FORMULA-3
```

Actual results:

```sh
brew bump --open-pr --formulae FORMULA-1
FORMULA-2
FORMULA-3
```

This actual result is probably unexpected. So, I fix it to use `>` to fold newlines.