### PR TITLE
setup-homebrew: handle stable on stable Docker images

### DIFF
--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -16,19 +16,30 @@ jobs:
         include:
           - os: macos-latest
             key: macos
+            stable: false
           - os: ubuntu-20.04
             key: ubuntu-20
+            stable: false
           - os: ubuntu-22.04
             key: ubuntu-22
+            stable: false
           - os: ubuntu-22.04
             key: docker-root
+            stable: false
             container:
               image: ghcr.io/homebrew/ubuntu22.04:master
               options: --user=root
           - os: ubuntu-22.04
             key: docker-linuxbrew
+            stable: false
             container:
               image: ghcr.io/homebrew/ubuntu22.04:master
+              options: --user=linuxbrew
+          - os: ubuntu-22.04
+            key: docker-linuxbrew-stable
+            stable: true
+            container:
+              image: ghcr.io/homebrew/ubuntu22.04:latest
               options: --user=linuxbrew
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
@@ -60,6 +71,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: ./setup-homebrew/
+        with:
+          stable: ${{ matrix.stable }}
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -144,7 +144,12 @@ if [[ "$GITHUB_REPOSITORY" =~ ^.+/brew$ ]]; then
     echo "repository-path=$HOMEBREW_REPOSITORY" >>"$GITHUB_OUTPUT"
 else
     git_retry -C "$HOMEBREW_REPOSITORY" fetch --force --tags origin
-    git -C "$HOMEBREW_REPOSITORY" checkout --force -B master origin/HEAD
+    git_retry -C "$HOMEBREW_REPOSITORY" remote set-head origin --auto
+    if [[ "${STABLE}" == "true" && "$(git -C "$HOMEBREW_REPOSITORY" symbolic-ref --short HEAD 2>/dev/null)" != "master" ]]; then
+      git -C "$HOMEBREW_REPOSITORY" branch --force master origin/HEAD
+    else
+      git -C "$HOMEBREW_REPOSITORY" checkout --force -B master origin/HEAD
+    fi
 
     if [[ -n "${HOMEBREW_TAP_REPOSITORY-}" ]]; then
         echo "repository-path=$HOMEBREW_TAP_REPOSITORY" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
* Don't assume `origin/HEAD` exists
* Don't checkout master first for stable - we don't support downgrades.