### PR TITLE
workflows/setup-commit-signing: generate testing key

### DIFF
--- a/.github/workflows/setup-commit-signing.yml
+++ b/.github/workflows/setup-commit-signing.yml
@@ -1,18 +1,18 @@
 name: Setup GPG commit signing
 
 on:
-  push:
+  pull_request:
     paths:
       - '**setup-commit-signing**'
       - 'package.json'
       - 'package-lock.json'
       - 'node_modules/**'
-    branches-ignore:
-      - master
+
+permissions:
+  contents: read
 
 jobs:
   commit-signing:
-    if: github.repository_owner == 'Homebrew' && github.actor != 'dependabot[bot]'
     strategy:
       matrix:
         container:
@@ -26,19 +26,51 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure git user
+        id: git-config
         uses: ./git-user-config/
         with:
           username: BrewTestBot
+      
+      - name: Generate GPG key
+        id: generate-gpg-key
+        env:
+          GIT_EMAIL: ${{ steps.git-config.outputs.email }}
+        run: |
+          export GNUPGHOME="/tmp/test-gpg-home"
+          mkdir -p "${GNUPGHOME}"
+          chmod 700 "${GNUPGHOME}"
+          PASSPHRASE=$(gpg --batch --gen-random --armor 1 32)
+          cat <<EOS | gpg --batch --generate-key
+            Key-Type: RSA
+            Key-Length: 4096
+            Key-Usage: sign
+            Subkey-Type: RSA
+            Subkey-Length: 4096
+            Subkey-Usage: sign
+            Name-Real: Homebrew/actions Test
+            Name-Comment: Test CI key
+            Name-Email: ${GIT_EMAIL}
+            Passphrase: ${PASSPHRASE}
+            Expire-Date: seconds=900
+          EOS
+          KEY=$(echo "${PASSPHRASE}" | gpg --batch --pinentry-mode=loopback --passphrase-fd=0 --armor --export-secret-subkeys "<${GIT_EMAIL}>" | base64 --wrap=0)
+          echo "::add-mask::${KEY}"
+          echo "::add-mask::${PASSPHRASE}"
+          echo "key<<!!!
+          ${KEY}
+          !!!" >> "${GITHUB_OUTPUT}"
+          echo "passphrase=${PASSPHRASE}" >> "${GITHUB_OUTPUT}"
+          rm -r "${GNUPGHOME}"
 
       - name: Set up commit signing
         id: set-up-commit-signing
         uses: ./setup-commit-signing/
         with:
-          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+          signing_key: ${{ steps.generate-gpg-key.outputs.key }}
 
       - name: Make changes and commit them
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           git checkout -b test-setup-commit-signing
 
           touch test.txt
@@ -47,7 +79,7 @@ jobs:
           git add test.txt
           git commit -m "test.txt: create and add content."
         env:
-          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+          HOMEBREW_GPG_PASSPHRASE: ${{ steps.generate-gpg-key.outputs.passphrase }}
 
       - name: Test
         run: |


### PR DESCRIPTION
Avoids the need to use a secret