### PR TITLE
remove-disabled-packages: add action

### DIFF
--- a/remove-disabled-packages/README.md
+++ b/remove-disabled-packages/README.md
@@ -1,0 +1,10 @@
+# Remove Disabled Packages Github Action
+
+An action that deletes packages that have a disable date of more than one year ago.
+
+## Usage
+
+```yaml
+- name: Run brew script
+  uses: Homebrew/actions/remove-disabled-packages@master
+```

--- a/remove-disabled-packages/action.yml
+++ b/remove-disabled-packages/action.yml
@@ -1,0 +1,17 @@
+name: Remove disabled packages
+description: Delete packages that have a disable date of more than one year ago
+branding:
+  icon: trash-2
+  color: red
+outputs:
+  packages-removed:
+    description: Whether any packages were removed or not
+    value: ${{steps.remove-packages.outputs.packages-removed}}
+runs:
+  using: composite
+  steps:
+    - run: brew ruby "$GITHUB_ACTION_PATH/main.rb"
+      id: remove-packages
+      shell: bash
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1

--- a/remove-disabled-packages/main.rb
+++ b/remove-disabled-packages/main.rb
@@ -1,0 +1,70 @@
+# typed: true
+# frozen_string_literal: true
+
+require "formula"
+require "cask"
+
+# The RemoveDisabledPackages class finds packages that have been disabled for over 12 months
+# and creates commits in the local repository to remove them.
+class RemoveDisabledPackages
+  ONE_YEAR_AGO = (Date.today << 12).freeze
+
+  def initialize(target_tap)
+    @target_tap = target_tap
+  end
+
+  def run
+    packages_to_remove = find_disabled(packages: Formula.all + Cask::Cask.all)
+
+    puts "Removing old packages..."
+
+    packages_to_remove.each { |package| FileUtils.rm sourcefile_path(package) }
+
+    tap_dir = @target_tap.path
+
+    out, err, status = Open3.capture3 "git", "-C", tap_dir.to_s, "status", "--porcelain", "--ignore-submodules=dirty"
+    raise err unless status.success?
+
+    if out.chomp.empty?
+      puts "No packages removed."
+      File.open(ENV.fetch("GITHUB_OUTPUT", nil), "a") { |f| f.puts("packages-removed=false") }
+      exit
+    end
+
+    git "-C", tap_dir.to_s, "add", "--all"
+
+    packages_to_remove.each do |package|
+      name = package.is_a?(Formula) ? package.name : package.token
+      puts "Removed `#{name}`."
+      git "-C", tap_dir.to_s, "commit", sourcefile_path(package), "--message",
+          "#{name}: remove #{package.is_a?(Formula) ? "formula" : "cask"}", "--quiet"
+    end
+
+    File.open(ENV.fetch("GITHUB_OUTPUT", nil), "a") { |f| f.puts("packages-removed=true") }
+  end
+
+  private
+
+  def git(*args)
+    system "git", *args
+    exit $CHILD_STATUS.exitstatus unless $CHILD_STATUS.success?
+  end
+
+  def find_disabled(packages: [])
+    puts "Finding disabled packages..."
+    packages.select do |package|
+      next false if package.tap != @target_tap
+      next false unless package.disabled?
+      next false if package.disable_date.nil?
+
+      package.disable_date < ONE_YEAR_AGO
+    end
+  end
+
+  def sourcefile_path(package)
+    package.is_a?(Formula) ? package.path : package.sourcefile_path
+  end
+end
+
+target_tap = Tap.fetch(ENV.fetch("GITHUB_REPOSITORY"))
+RemoveDisabledPackages.new(target_tap).run


### PR DESCRIPTION
This PR adds a modified version of the existing `remove-disabled-formulae` action that would work across both `homebrew-core` and `homebrew-cask`, and be useable in a repository that includes both Formula and Casks.

It may be worthwhile adding an additional feature to pass a variable for the amount of months a package should be disabled before being removed, as there may be a difference in process between `homebrew-core` and `homebrew-cask`.