### PR TITLE
setup-homebrew: add brew-gh-api-token setting

### DIFF
--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: Token to be used for GitHub authentication (if using private repositories). This token will persist through other steps for the duration of the job.
     required: false
     default: ""
+  brew-gh-api-token:
+    description: Token to be used for GitHub API operations within `brew`. This is confusingly not the same thing as `token` above.
+    required: false
+    default: "${{ secrets.GITHUB_TOKEN }}"
   stable:
     description: Use the latest stable `homebrew/brew` tag.
     required: false

--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -28,7 +28,7 @@ inputs:
   brew-gh-api-token:
     description: Token to be used for GitHub API operations within `brew`. This is confusingly not the same thing as `token` above.
     required: false
-    default: "${{ secrets.GITHUB_TOKEN }}"
+    default: ""
   stable:
     description: Use the latest stable `homebrew/brew` tag.
     required: false

--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -28,7 +28,7 @@ inputs:
   brew-gh-api-token:
     description: Token to be used for GitHub API operations within `brew`. This is confusingly not the same thing as `token` above.
     required: false
-    default: ""
+    default: "${{ github.token }}"
   stable:
     description: Use the latest stable `homebrew/brew` tag.
     required: false

--- a/setup-homebrew/main.mjs
+++ b/setup-homebrew/main.mjs
@@ -1,4 +1,4 @@
-import {exec} from "@actions/exec"
+import { exec } from "@actions/exec"
 import core from "@actions/core"
 
 // GitHub Actions does not support shell `post` actions and thus requires a JS wrapper.
@@ -10,7 +10,8 @@ try {
     core.getInput("test-bot"),
     core.getInput("debug"),
     core.getInput("token"),
-    core.getInput("stable")
+    core.getInput("stable"),
+    core.getIDToken("brew-gh-api-token"),
   ])
 } catch (error) {
   core.setFailed(error.message)

--- a/setup-homebrew/main.mjs
+++ b/setup-homebrew/main.mjs
@@ -11,7 +11,7 @@ try {
     core.getInput("debug"),
     core.getInput("token"),
     core.getInput("stable"),
-    core.getIDToken("brew-gh-api-token"),
+    core.getInput("brew-gh-api-token"),
   ])
 } catch (error) {
   core.setFailed(error.message)

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -8,6 +8,7 @@ TEST_BOT="${3}"
 DEBUG="${4}"
 TOKEN="${5}"
 STABLE="${6}"
+BREW_GH_API_TOKEN="${7}"
 
 if [[ "${DEBUG}" == "true" ]]; then
     set -x
@@ -120,6 +121,11 @@ if [[ ! "$GITHUB_REPOSITORY" =~ ^.+/(home|linux)brew-core$ ]]; then
     # This is set by GitHub Actions by default but we don't want that.
     echo HOMEBREW_NO_INSTALL_FROM_API= >>"$GITHUB_ENV"
     unset HOMEBREW_NO_INSTALL_FROM_API
+fi
+
+# Configure HOMEBREW_GITHUB_API_TOKEN (needed for attestations)
+if [[ -n "${BREW_GH_API_TOKEN}" ]]; then
+    echo "HOMEBREW_GITHUB_API_TOKEN=${BREW_GH_API_TOKEN}" >> "${GITHUB_ENV}"
 fi
 
 # Use an access token to checkout (private repositories)


### PR DESCRIPTION
This should default to the current workflow runner's GITHUB_TOKEN, and should not need to be configured by the majority of users.

The primary purpose of this is to pre-configure
`HOMEBREW_GITHUB_API_TOKEN` so that attestations are verified in the CI.