### PR TITLE
Handle input strings more robustly

### DIFF
--- a/.github/workflows/vendor-node-modules.yml
+++ b/.github/workflows/vendor-node-modules.yml
@@ -41,11 +41,12 @@ jobs:
       - name: Check out pull request
         id: checkout
         run: |
-          gh pr checkout '${{ github.event.pull_request.number || github.event.inputs.pull_request }}'
+          gh pr checkout "$PR"
 
           branch="$(git branch --show-current)"
           echo "branch=${branch}" >> "$GITHUB_OUTPUT"
         env:
+          PR: ${{ github.event.pull_request.number || github.event.inputs.pull_request }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Vendor node_modules
         run: npm install

--- a/brew-script/action.yml
+++ b/brew-script/action.yml
@@ -15,11 +15,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: |
-        cat << 'EOF' > "/tmp/brew-script-$GITHUB_SHA"
-        ${{inputs.script}}
-        EOF
+    - run: echo "$SCRIPT" > "/tmp/brew-script-$GITHUB_SHA"
       shell: bash
+      env:
+        SCRIPT: ${{inputs.script}}
     - run: brew ruby "/tmp/brew-script-$GITHUB_SHA"
       shell: bash
       env:

--- a/failures-summary-and-bottle-result/action.yml
+++ b/failures-summary-and-bottle-result/action.yml
@@ -28,16 +28,24 @@ runs:
           sudo chown "$(whoami)" "$GITHUB_STEP_SUMMARY"
         fi
 
-        full_result_path="${{ inputs.workdir }}/${{ inputs.result_path }}"
+        full_result_path="$WORKDIR/$RESULT_PATH"
 
         [[ -s "$full_result_path" ]] || exit 0
 
-        printf '### ${{ inputs.step_name }}\n' >> "$GITHUB_STEP_SUMMARY"
-        "${{ inputs.collapse }}" && printf '\n<details><summary>Details</summary>\n<p>\n\n' >> "$GITHUB_STEP_SUMMARY"
-        printf '```\n' >> "$GITHUB_STEP_SUMMARY"
-        sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$full_result_path" | tee -a "$GITHUB_STEP_SUMMARY"
-        printf '\n```\n' >> "$GITHUB_STEP_SUMMARY"
-        "${{ inputs.collapse }}" && printf '\n</p>\n</details>\n' >> "$GITHUB_STEP_SUMMARY"
+        {
+          printf '%s' "### $STEP_NAME\n"
+          [[ "$COLLAPSE" != true ]] || printf '%s' '\n<details><summary>Details</summary>\n<p>\n\n'
+          printf '%s' '```\n'
+          # Remove colours from the output
+          sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$full_result_path"
+          printf '%s' '\n```\n'
+          [[ "$COLLAPSE" != true ]] || printf '%s' '\n</p>\n</details>\n'
+        } | tee -a "$GITHUB_STEP_SUMMARY"
 
         rm "$full_result_path"
       shell: /bin/bash -euo pipefail {0}
+      env:
+        WORKDIR: ${{ inputs.workdir }}
+        RESULT_PATH: ${{ inputs.result_path }}
+        STEP_NAME: ${{ inputs.step_name }}
+        COLLAPSE: ${{ inputs.collapse }}

--- a/find-related-workflow-run-id/action.yml
+++ b/find-related-workflow-run-id/action.yml
@@ -22,6 +22,7 @@ runs:
       id: result
       env:
         GH_TOKEN: ${{ inputs.token }}
+        WORKFLOW_NAME: ${{ inputs.workflow-name }}
         WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ inputs.repository }}/actions/runs/${{ inputs.run-id }}
         QUERY: >-
           query($url: URI!) {
@@ -49,8 +50,8 @@ runs:
           gh api graphql \
             --field url="$WORKFLOW_RUN_URL" \
             --raw-field query="$QUERY" \
-            --jq '.data.resource.checkSuite.commit.checkSuites.nodes |
-                    map(select(.workflowRun.workflow.name == "${{ inputs.workflow-name }}")) |
-                    last | .workflowRun.databaseId'
+            --jq ".data.resource.checkSuite.commit.checkSuites.nodes |
+                    map(select(.workflowRun.workflow.name == \"$WORKFLOW_NAME\")) |
+                    last | .workflowRun.databaseId"
         )"
         echo "workflow_run_id=$run_id" >> "$GITHUB_ENV"

--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -57,9 +57,12 @@ runs:
     - name: Count bottles
       id: bottles
       if: always()
-      run: '"${GITHUB_ACTION_PATH}/count-bottles.sh" "${{ inputs.debug }}"'
+      run: |
+        "${GITHUB_ACTION_PATH}/count-bottles.sh" "${DEBUG}"
       working-directory: ${{ inputs.bottles-directory }}
       shell: /bin/bash -euo pipefail {0}
+      env:
+        DEBUG: ${{ runner.debug == '1' }}
 
     - name: Upload failed bottles
       if: always() && steps.bottles.outputs.failures > 0

--- a/setup-commit-signing/action.yml
+++ b/setup-commit-signing/action.yml
@@ -12,6 +12,8 @@ runs:
   using: composite
   steps:
     - run: |
-        "$GITHUB_ACTION_PATH/main.sh" '${{ inputs.signing_key }}'
+        "$GITHUB_ACTION_PATH/main.sh" "$SIGNING_KEY"
       shell: bash
       id: setup
+      env:
+        SIGNING_KEY: ${{ inputs.signing_key }}


### PR DESCRIPTION
Avoid using inputs expanded with the `${{ .. }}` syntax in shell scripts to prevent code injection.

Also:

- `failures-summary-and-bottle-result`: make sure every `printf` gets a format string (`%s`) so that we don't get unexpected format sequences from the input.
- `post-build`: fix use of non-existent input `debug`.
