### PR TITLE
bump-packages: fix input handling

### DIFF
--- a/bump-packages/action.yml
+++ b/bump-packages/action.yml
@@ -35,6 +35,7 @@ runs:
       shell: bash
       if: inputs.formulae != ''
       env:
+        INPUT_FORMULAE: ${{ inputs.formulae }}
         HOMEBREW_DEVELOPER: "1"
         HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}
     - name: Bump casks
@@ -49,5 +50,6 @@ runs:
       shell: bash
       if: inputs.casks != ''
       env:
+        INPUT_CASKS: ${{ inputs.casks }}
         HOMEBREW_DEVELOPER: "1"
         HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
Composite actions don't get the `INPUT_` variables automatically [^1].

[^1]: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#example-specifying-inputs
