### PR TITLE
pre-build: set HOMEBREW_NO_UPDATE_REPORT_NEW

### DIFF
--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -22,6 +22,8 @@ runs:
         core: true
         cask: false
         test-bot: true
+      env:
+        HOMEBREW_NO_UPDATE_REPORT_NEW: 1
 
     - run: brew test-bot --only-cleanup-before
       if: fromJson(inputs.cleanup)


### PR DESCRIPTION
The new formula list is very noisy when the images haven't been updated in a while and is not useful information at all for Homebrew/core CI purposes.