### PR TITLE
failures-summary: remove markdown formatting from actions log

### DIFF
--- a/failures-summary-and-bottle-result/action.yml
+++ b/failures-summary-and-bottle-result/action.yml
@@ -36,11 +36,15 @@ runs:
           printf '%s\n\n' "### $STEP_NAME"
           [[ "$COLLAPSE" != true ]] || printf '%s\n' '<details><summary>Details</summary>' '<p>'
           printf '\n%s\n' '```'
-          # Remove colours from the output
-          sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$full_result_path"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        # Remove colours from the output
+        sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$full_result_path" | tee -a "$GITHUB_STEP_SUMMARY"
+
+        {
           printf '\n%s\n' '```'
           [[ "$COLLAPSE" != true ]] || printf '%s\n' '</p>' '</details>'
-        } | tee -a "$GITHUB_STEP_SUMMARY"
+        } >> "$GITHUB_STEP_SUMMARY"
 
         rm "$full_result_path"
       shell: /bin/bash -euo pipefail {0}


### PR DESCRIPTION
We don't want to send the markdown formatting parts to the actions log.
Let's add them only to `GITHUB_STEP_SUMMARY`.
