### PR TITLE
create-pull-request: output `node_id`

### DIFF
--- a/create-pull-request/main.mjs
+++ b/create-pull-request/main.mjs
@@ -26,6 +26,7 @@ async function main() {
 
     const response = await client.rest.pulls.create(prRequest)
     const prNumber = response.data.number
+    const prNodeId = response.data.node_id
 
     if (labels) {
       await client.rest.issues.addLabels({
@@ -46,6 +47,7 @@ async function main() {
     }
 
     core.setOutput("number", prNumber)
+    core.setOutput("node_id", prNodeId)
   } catch (error) {
     core.setFailed(error)
   }


### PR DESCRIPTION
This will allow us to use cheaper calls directly with `gh api` instead
of `gh pr merge`.
