### PR TITLE
create-pull-request: fix empty string handling

### DIFF
--- a/create-pull-request/main.mjs
+++ b/create-pull-request/main.mjs
@@ -29,6 +29,9 @@ async function main() {
     const response = await client.rest.pulls.create(prRequest)
     const prNumber = response.data.number
     const prNodeId = response.data.node_id
+    const prUrl = response.data.html_url
+
+    core.info(`Created pull request ${prUrl}`)
 
     if (labels.length > 0) {
       await client.rest.issues.addLabels({
@@ -37,6 +40,8 @@ async function main() {
         issue_number: prNumber,
         labels
       })
+
+      core.info(`Added labels ${labels.join(", ")} to pull request`)
     }
 
     if (reviewers.length > 0) {
@@ -46,6 +51,8 @@ async function main() {
         pull_number: prNumber,
         reviewers
       })
+
+      core.info(`Requested review from ${reviewers.join(", ")} for pull request`)
     }
 
     core.setOutput("number", prNumber)

--- a/create-pull-request/main.mjs
+++ b/create-pull-request/main.mjs
@@ -11,8 +11,10 @@ async function main() {
     const title = core.getInput("title")
     const body = core.getInput("body")
 
-    const labels = core.getInput("labels").split(",")
-    const reviewers = core.getInput("reviewers").split(",")
+    const labelsInput = core.getInput("labels")
+    const labels = labelsInput ? labelsInput.split(",") : []
+    const reviewersInput = core.getInput("reviewers")
+    const reviewers = reviewersInput ? reviewersInput.split(",") : []
 
     const client = github.getOctokit(token)
 
@@ -28,7 +30,7 @@ async function main() {
     const prNumber = response.data.number
     const prNodeId = response.data.node_id
 
-    if (labels) {
+    if (labels.length > 0) {
       await client.rest.issues.addLabels({
         owner,
         repo,
@@ -37,7 +39,7 @@ async function main() {
       })
     }
 
-    if (reviewers) {
+    if (reviewers.length > 0) {
       await client.rest.pulls.requestReviewers({
         owner,
         repo,


### PR DESCRIPTION
`core.getInput` returns an empty string if the value is not defined [^1]. Splitting an empty string in JavaScript returns an array with an empty string, which is truthy. That means the checks for labels and reviewers are always true, even if the input is not defined.

```node
> "".split("/")
[ '' ]
> Boolean([""])
true
```

In addition, add log output so that it's easier to figure out what's going on.

[^1]: https://github.com/actions/toolkit/blob/6dd369c0e648ed58d0ead326cf2426906ea86401/packages/core/src/core.ts#L120
