### PR TITLE
find-related-workflow-run-id: fix action definition

### DIFF
--- a/find-related-workflow-run-id/action.yml
+++ b/find-related-workflow-run-id/action.yml
@@ -19,7 +19,7 @@ outputs:
   workflow-run-id:
     description: >
       ID of the related workflow run.
-      Also available as `${{ env.workflow_run_id }}`.
+      Also available as `env.workflow_run_id`.
 runs:
   using: node20
   main: main.mjs


### PR DESCRIPTION
It turned out that `${{ }}` context access cannot be used here.

Fixes failure seen at https://github.com/Homebrew/homebrew-core/actions/runs/10973777949/job/30471527341.
