### PR TITLE
create-or-update-issue: add more inputs

### DIFF
--- a/create-or-update-issue/README.md
+++ b/create-or-update-issue/README.md
@@ -21,4 +21,5 @@ closing it based on the outcome of a previous step.
     # If true: close an existing issue with the same title as completed, if such
     # an issue is found; otherwise, do nothing.
     close-existing: ${{ steps.<step-id>.conclusion == 'success' }}
+    close-comment: An optional comment to post when closing an issue
 ```

--- a/create-or-update-issue/README.md
+++ b/create-or-update-issue/README.md
@@ -21,5 +21,7 @@ closing it based on the outcome of a previous step.
     # If true: close an existing issue with the same title as completed, if such
     # an issue is found; otherwise, do nothing.
     close-existing: ${{ steps.<step-id>.conclusion == 'success' }}
+    # If specified: only close an existing issue created by the specified user.
+    close-from-author: original-issue-author
     close-comment: An optional comment to post when closing an issue
 ```

--- a/create-or-update-issue/main.mjs
+++ b/create-or-update-issue/main.mjs
@@ -17,6 +17,7 @@ async function main() {
 
     const updateExisting = core.getBooleanInput("update-existing");
     const closeExisting = core.getBooleanInput("close-existing");
+    const closeComment = core.getInput("close-comment");
 
     const client = github.getOctokit(token);
 
@@ -57,6 +58,17 @@ async function main() {
         return;
       }
       if (closeExisting) {
+        if (closeComment) {
+          const response = await client.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: existingIssue.number,
+            body: closeComment,
+          });
+          const commentUrl = response.data.html_url;
+          core.info(`Posted comment under existing issue: ${commentUrl}`);
+        }
+
         const response = await client.rest.issues.update({
           owner,
           repo,

--- a/create-or-update-issue/main.mjs
+++ b/create-or-update-issue/main.mjs
@@ -17,22 +17,27 @@ async function main() {
 
     const updateExisting = core.getBooleanInput("update-existing");
     const closeExisting = core.getBooleanInput("close-existing");
+    const closeFromAuthor = core.getInput("close-from-author");
     const closeComment = core.getInput("close-comment");
 
     const client = github.getOctokit(token);
 
     let existingIssue = undefined;
     if (updateExisting || closeExisting) {
+      const params = {
+        owner,
+        repo,
+        state: "open",
+        sort: "created",
+        direction: "desc",
+        per_page: 100,
+      };
+      if (closeFromAuthor) {
+        params.creator = closeFromAuthor;
+      }
       for await (const response of client.paginate.iterator(
         client.rest.issues.listForRepo,
-        {
-          owner,
-          repo,
-          state: "open",
-          sort: "created",
-          direction: "desc",
-          per_page: 100,
-        }
+        params
       )) {
         existingIssue = response.data.find((issue) => issue.title === title);
         if (existingIssue) {

--- a/create-or-update-issue/main.test.mjs
+++ b/create-or-update-issue/main.test.mjs
@@ -93,6 +93,9 @@ describe("create-issue", async () => {
     mockInput("update-existing", "false");
     mockInput("close-existing", "true");
 
+    const closeFromAuthor = "some-user";
+    mockInput("close-from-author", closeFromAuthor);
+
     const closeComment = "Deployment succeeded.\nClosing issue.";
     mockInput("close-comment", closeComment);
 
@@ -101,7 +104,13 @@ describe("create-issue", async () => {
     mockPool.intercept({
       method: "GET",
       path: `/repos/${GITHUB_REPOSITORY}/issues?` +
-        `direction=desc&per_page=100&sort=created&state=open`,
+        [
+          `creator=${closeFromAuthor}`,
+          "direction=desc",
+          "per_page=100",
+          "sort=created",
+          "state=open",
+        ].join("&"),
       headers: {
         Authorization: `token ${token}`,
       },

--- a/create-or-update-issue/main.test.mjs
+++ b/create-or-update-issue/main.test.mjs
@@ -45,7 +45,7 @@ describe("create-issue", async () => {
     await loadMain();
   });
 
-  it("for advanced use case with `close-existing: true`", async () => {
+  it("updates an issue when `update-existing: true`", async () => {
     mockInput("update-existing", "true");
     mockInput("close-existing", "false");
 
@@ -89,9 +89,12 @@ describe("create-issue", async () => {
     await loadMain();
   });
 
-  it("for advanced use case with `close-existing: true`", async () => {
+  it("closes an existing issue when `close-existing: true`", async () => {
     mockInput("update-existing", "false");
     mockInput("close-existing", "true");
+
+    const closeComment = "Deployment succeeded.\nClosing issue.";
+    mockInput("close-comment", closeComment);
 
     const mockPool = githubMockPool();
 
@@ -114,6 +117,21 @@ describe("create-issue", async () => {
         number: issueNumber,
       },
     ]);
+
+    mockPool.intercept({
+      method: "POST",
+      path: `/repos/${GITHUB_REPOSITORY}/issues/${issueNumber}/comments`,
+      headers: {
+        Authorization: `token ${token}`,
+      },
+      body: (htmlBody) => util.isDeepStrictEqual(JSON.parse(htmlBody), {
+        body: closeComment,
+      }),
+    }).defaultReplyHeaders({
+      "Content-Type": "application/json",
+    }).reply(200, {
+      html_url: "https://github.com/owner/repo/issues/12345#issuecomment-67890",
+    });
 
     mockPool.intercept({
       method: "PATCH",


### PR DESCRIPTION
- create-or-update-issue: add `close-comment` input
  This allows posting a customised comment, like "The most recent deployment succeeded, closing issue", before closing an issue. This is used in formulae.brew.sh [^1].
- create-or-update-issue: add `close-from-author` input
  This makes it possible to only check issues created by a specified user when searching for an existing issue. This is used in formulae.brew.sh [^2].

[^1]: https://github.com/Homebrew/formulae.brew.sh/blob/cc00b2d9476b85bba59c8469566774c496bbf381/.github/workflows/tests.yml#L272-L279
[^2]: https://github.com/Homebrew/formulae.brew.sh/blob/cc00b2d9476b85bba59c8469566774c496bbf381/.github/workflows/tests.yml#L257
