### PR TITLE
create-or-update-issue: add missing inputs to action definition

### DIFF
--- a/create-or-update-issue/README.md
+++ b/create-or-update-issue/README.md
@@ -21,7 +21,8 @@ closing it based on the outcome of a previous step.
     # If true: close an existing issue with the same title as completed, if such
     # an issue is found; otherwise, do nothing.
     close-existing: ${{ steps.<step-id>.conclusion == 'success' }}
-    # If specified: only close an existing issue created by the specified user.
+    # If specified and `close-existing` is true: only close an existing issue
+    # created by the specified author.
     close-from-author: original-issue-author
     close-comment: An optional comment to post when closing an issue
 ```

--- a/create-or-update-issue/action.yml
+++ b/create-or-update-issue/action.yml
@@ -38,6 +38,16 @@ inputs:
       NOTE: if set to `true`, no new issue will be created!
     required: false
     default: "false"
+  close-from-author:
+    description: >
+      If specified and `close-existing` is `true`, only close an existing issue
+      created by the specified author
+    required: false
+  close-comment:
+    description: >
+      If specified and `close-existing` is `true`, post this comment when
+      closing an existing issue
+    required: false
 outputs:
   outcome:
     description: >


### PR DESCRIPTION
This was missed in ef36cd0 and 332f53a.

In addition, clarify usage in readme.
