### PR TITLE
bump-packages: fix fork input handling

### DIFF
--- a/bump-packages/action.yml
+++ b/bump-packages/action.yml
@@ -36,6 +36,7 @@ runs:
       if: inputs.formulae != ''
       env:
         INPUT_FORMULAE: ${{ inputs.formulae }}
+        INPUT_FORK: ${{ inputs.fork }}
         HOMEBREW_DEVELOPER: "1"
         HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}
     - name: Bump casks
@@ -51,5 +52,6 @@ runs:
       if: inputs.casks != ''
       env:
         INPUT_CASKS: ${{ inputs.casks }}
+        INPUT_FORK: ${{ inputs.fork }}
         HOMEBREW_DEVELOPER: "1"
         HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
This fixes the `fork` input so that the composite actions actually get the `INPUT_FORK` variable.

This was never passed correctly, meaning `brew bump --no-fork ...` is what always ran, even when `fork` was set to `true`.