### PR TITLE
workflows: fix artipacked zizmor findings

### DIFF
--- a/.github/workflows/create-gcloud-instance.yml
+++ b/.github/workflows/create-gcloud-instance.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Check scripts
         run: shellcheck --enable=all create-gcloud-instance/*.sh

--- a/.github/workflows/git-try-push.yml
+++ b/.github/workflows/git-try-push.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Prepare remote
         run: |

--- a/.github/workflows/git-user-config.yml
+++ b/.github/workflows/git-user-config.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Config
         id: config

--- a/.github/workflows/setup-commit-signing.yml
+++ b/.github/workflows/setup-commit-signing.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Configure git user
         id: git-config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/.github/workflows/wait-for-idle-runner.yml
+++ b/.github/workflows/wait-for-idle-runner.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Check scripts
         run: node --check wait-for-idle-runner/main.js


### PR DESCRIPTION
Trying again to fix these. I set `persist-credentials: true` for any jobs that had git operations, and `false` for the others. Let me know if I misunderstood.