### PR TITLE
workflows/git-user-config: fix template-injection zizmor findings

### DIFF
--- a/.github/workflows/git-user-config.yml
+++ b/.github/workflows/git-user-config.yml
@@ -24,8 +24,11 @@ jobs:
           username: BrewTestBot
 
       - name: Test
+        env:
+          CONFIG_OUTPUT_NAME: ${{steps.config.outputs.name}}
+          CONFIG_OUTPUT_EMAIL: ${{steps.config.outputs.email}}
         run: |
-          test "${{steps.config.outputs.name}}" = "BrewTestBot"
-          test "${{steps.config.outputs.email}}" = "1589480+BrewTestBot@users.noreply.github.com"
+          test "$CONFIG_OUTPUT_NAME" = "BrewTestBot"
+          test "$CONFIG_OUTPUT_EMAIL" = "1589480+BrewTestBot@users.noreply.github.com"
           test "$(git config --global user.name)" = "BrewTestBot"
           test "$(git config --global user.email)" = "1589480+BrewTestBot@users.noreply.github.com"


### PR DESCRIPTION
Avoid template injection by using environment variables to represent template values.
