### PR TITLE
workflows: remove no-op ssh signing value

### DIFF
--- a/.github/workflows/setup-commit-signing.yml
+++ b/.github/workflows/setup-commit-signing.yml
@@ -49,7 +49,6 @@ jobs:
         uses: ./setup-commit-signing/
         with:
           signing_key: ${{ steps.generate-ssh-key.outputs.key }}
-          ssh: true
 
       - name: Make changes and commit them
         run: |

--- a/.github/workflows/vendor-node-modules.yml
+++ b/.github/workflows/vendor-node-modules.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Set up commit signing
         uses: ./setup-commit-signing/
         with:
-          ssh: true
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
       - name: Check out pull request
         id: checkout


### PR DESCRIPTION
Now that we've removed all the GPG code, this is a no-op.