### PR TITLE
setup-homebrew: homebrew-cask now uses `main`.

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -266,7 +266,7 @@ else
             git_retry -C "$HOMEBREW_CASK_REPOSITORY" config fetch.prune true
             git_retry -C "$HOMEBREW_CASK_REPOSITORY" fetch --force origin
             git_retry -C "$HOMEBREW_CASK_REPOSITORY" remote set-head origin --auto
-            git -C "$HOMEBREW_CASK_REPOSITORY" checkout --force -B master origin/HEAD
+            git -C "$HOMEBREW_CASK_REPOSITORY" checkout --force -B main origin/HEAD
         else
             ohai "Cloning Homebrew/cask..."
             git_retry clone https://github.com/Homebrew/homebrew-cask "${HOMEBREW_CASK_REPOSITORY}"


### PR DESCRIPTION
To be merged when homebrew-test-bot is using a default `main` branch.

See https://github.com/Homebrew/brew/issues/17296