### PR TITLE
workflows/sync-default-branches: use faster version.

### DIFF
--- a/.github/workflows/sync-default-branches.yml
+++ b/.github/workflows/sync-default-branches.yml
@@ -45,19 +45,20 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: true
 
-      - name: Setup target branch
+      - name: Get target SHA
+        id: sha
         run: |
-          git checkout "${TARGET_BRANCH}" || git checkout -b "${TARGET_BRANCH}"
-          git reset --hard "origin/${SOURCE_BRANCH}"
+          TARGET_SHA=$(git ls-remote origin "refs/heads/${SOURCE_BRANCH}" | cut -f1)
+          echo "target=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
         env:
           SOURCE_BRANCH: ${{ steps.branches.outputs.source }}
-          TARGET_BRANCH: ${{ steps.branches.outputs.target }}
 
       - name: Push target branch
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-        run: git push origin "${TARGET_BRANCH}" --force-with-lease
+        run: git push origin "${TARGET_SHA}:refs/heads/${TARGET_BRANCH}" --force
         env:
+          TARGET_SHA: ${{ steps.sha.outputs.target }}
           TARGET_BRANCH: ${{ steps.branches.outputs.target }}


### PR DESCRIPTION
Ported over from homebrew-core.