### PR TITLE
setup-homebrew: fix bad `git init` command

### DIFF
--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -195,7 +195,7 @@ if [[ "$GITHUB_REPOSITORY" =~ ^.+/(home|linux)brew-core$ ]]; then
     else
         mkdir -vp "$HOMEBREW_CORE_REPOSITORY"
         cd "$HOMEBREW_CORE_REPOSITORY"
-        git init -c init.defaultBranch=main
+        git -c init.defaultBranch=main init
         git remote add origin "https://github.com/$GITHUB_REPOSITORY"
     fi
     git_retry fetch origin "$GITHUB_SHA" '+refs/heads/*:refs/remotes/origin/*'


### PR DESCRIPTION
The `-c` flag should come before `init`.
