### PR TITLE
Potential fix for code scanning alert no. 49: Code injection

### DIFF
--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -68,7 +68,7 @@ runs:
         rm -rvf "${BOTTLES_DIR:?}"
         mkdir "${BOTTLES_DIR:?}"
 
-        if [[ "${{ runner.os }}" = Linux ]]; then
+        if [[ "$RUNNER_OS" = Linux ]]; then
           bottle_specifier="{ubuntu,linux}"
         else
           bottle_specifier="{macos-${MACOS_VERSION},${MACOS_VERSION}-${ARCH}}"
@@ -80,6 +80,7 @@ runs:
         BOTTLES_DIR: ${{ inputs.bottles-directory }}
         MACOS_VERSION: ${{ steps.setup-cache.outputs.macos_version }}
         ARCH: ${{ steps.setup-cache.outputs.arch }}
+        RUNNER_OS: ${{ runner.os }}
 
     - name: Download bottles from GitHub Actions
       if: fromJson(inputs.download-bottles)

--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -80,7 +80,6 @@ runs:
         BOTTLES_DIR: ${{ inputs.bottles-directory }}
         MACOS_VERSION: ${{ steps.setup-cache.outputs.macos_version }}
         ARCH: ${{ steps.setup-cache.outputs.arch }}
-        RUNNER_OS: ${{ runner.os }}
 
     - name: Download bottles from GitHub Actions
       if: fromJson(inputs.download-bottles)


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/actions/security/code-scanning/49](https://github.com/Homebrew/actions/security/code-scanning/49)

To fix the problem, we should avoid using `${{ runner.os }}` directly in the shell script. Instead, we should set an environment variable (e.g., `RUNNER_OS`) to the value of `${{ runner.os }}` in the `env:` block of the step, and then reference it in the shell script using the native shell variable syntax (`$RUNNER_OS`). This change should be made in the step starting at line 65, specifically in the `if` statement on line 71. No additional imports or methods are needed; only the `env:` block and the shell script need to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
