### PR TITLE
pre-build: tap `homebrew/cask`

### DIFF
--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: Homebrew/actions/setup-homebrew@main
       with:
         core: true
-        cask: false
+        cask: true
         test-bot: true
       env:
         HOMEBREW_NO_UPDATE_REPORT_NEW: 1


### PR DESCRIPTION
This is required for the cask name conflict audit in `homebrew/core` to work. Without `homebrew/cask` tapped, `CoreCaskTap.instance.cask_tokens` returns an empty array, so the condition at [^1] always evaluates to false.

[^1]: https://github.com/Homebrew/brew/blob/211b7494628de92465fefcf80d89ab2b01b13df5/Library/Homebrew/formula_auditor.rb#L194
