### PR TITLE
ci: drop more workflow permissions

### DIFF
--- a/.github/workflows/create-gcloud-instance.yml
+++ b/.github/workflows/create-gcloud-instance.yml
@@ -12,6 +12,8 @@ on:
       - "package-lock.json"
       - "node_modules/**"
 
+permissions: {}
+
 jobs:
   syntax:
     runs-on: ubuntu-latest

--- a/.github/workflows/git-user-config.yml
+++ b/.github/workflows/git-user-config.yml
@@ -3,10 +3,12 @@ name: Git user config
 on:
   pull_request:
     paths:
-      - '**git-user-config**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'node_modules/**'
+      - "**git-user-config**"
+      - "package.json"
+      - "package-lock.json"
+      - "node_modules/**"
+
+permissions: {}
 
 jobs:
   user-config:

--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -8,6 +8,8 @@ on:
       - "package-lock.json"
       - "node_modules/**"
 
+permissions: {}
+
 jobs:
   setup:
     strategy:

--- a/.github/workflows/wait-for-idle-runner.yml
+++ b/.github/workflows/wait-for-idle-runner.yml
@@ -12,6 +12,8 @@ on:
       - "package-lock.json"
       - "node_modules/**"
 
+permissions: {}
+
 jobs:
   syntax:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed that we had a few of these workflows without `permissions: {}` left. 

Based on a cursory scan there should be no functional changes from dropping these permissions, since none of these workflows should require any permissions.