### PR TITLE
Cleanup symlink files correctly in post step of setup-homebrew

### DIFF
--- a/setup-homebrew/post.sh
+++ b/setup-homebrew/post.sh
@@ -11,7 +11,7 @@ fi
 
 # Remove symlink and move files back.
 if [[ -n "${STATE_TAP_SYMLINK-}" ]]; then
-  rm "${STATE_TAP_SYMLINK}"
+  rm -rf "${STATE_TAP_SYMLINK}"
   mkdir "${STATE_TAP_SYMLINK}"
   (shopt -s dotglob; mv "${GITHUB_WORKSPACE}"/* "${STATE_TAP_SYMLINK}" )
   echo "Reset tap symlink."


### PR DESCRIPTION
- to fix errors in post cleanup

error logs in https://github.com/langgenius/homebrew-dify/actions/runs/18654118216/job/53178862011?pr=19#step:13:3
```
Post job cleanup.
/bin/bash /home/runner/work/_actions/Homebrew/actions/main/setup-homebrew/post.sh false
rm: cannot remove '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/langgenius/homebrew-dify': No such file or directory
Error: The process '/bin/bash' failed with exit code 1
```