### PR TITLE
pre-build: replace `GITHUB_ENV` with `GITHUB_OUTPUT`

### DIFF
--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -40,17 +40,17 @@ runs:
           arch="$(uname -m)"
           cache_key_prefix="${macos_version}-${arch}"
         fi
-        echo "cache_key_prefix=${cache_key_prefix}" >> "$GITHUB_ENV"
-        echo "macos_version=${macos_version:-}" >> "$GITHUB_OUTPUT"
-        echo "arch=${arch:-}" >> "$GITHUB_OUTPUT"
+        echo "cache_key_prefix=${cache_key_prefix}" >> "${GITHUB_OUTPUT}"
+        echo "macos_version=${macos_version:-}" >> "${GITHUB_OUTPUT}"
+        echo "arch=${arch:-}" >> "${GITHUB_OUTPUT}"
 
     - name: Cache Homebrew Bundler RubyGems
       id: cache
       uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-        key: ${{ env.cache_key_prefix }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-        restore-keys: ${{ env.cache_key_prefix }}-rubygems-
+        key: ${{ steps.setup-cache.outputs.cache_key_prefix }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+        restore-keys: ${{ steps.setup-cache.outputs.cache_key_prefix }}-rubygems-
 
     - name: Run brew test-bot --only-setup
       run: |


### PR DESCRIPTION
Fixes https://github.com/Homebrew/actions/security/code-scanning/75

Following https://docs.zizmor.sh/audits/#remediation_10