### PR TITLE
workflows: switch to `ubuntu-slim` where possible

### DIFF
--- a/.github/workflows/git-try-push.yml
+++ b/.github/workflows/git-try-push.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   try-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/git-user-config.yml
+++ b/.github/workflows/git-user-config.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   user-config:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/sync-default-branches.yml
+++ b/.github/workflows/sync-default-branches.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/wait-for-idle-runner.yml
+++ b/.github/workflows/wait-for-idle-runner.yml
@@ -16,7 +16,7 @@ permissions: {}
 
 jobs:
   syntax:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
Results from [`gh-slimify`](https://github.com/fchimpan/gh-slimify):

```
✓ Scan complete

📄 .github/workflows/setup-homebrew.yml
  ❌ Cannot migrate (1 job(s)):
     • "Setup Homebrew on ${{ matrix.name }}" (L46)
       ❌ does not run on ubuntu-latest
       .github/workflows/setup-homebrew.yml:46

📄 .github/workflows/stale-issues.yml
  ✨ Already using ubuntu-slim (2 job(s)):
     • "stale" (L34)
       .github/workflows/stale-issues.yml:34
     • "bump-pr-stale" (L64)
       .github/workflows/stale-issues.yml:64

📄 .github/workflows/git-user-config.yml
  ✅ Safe to migrate (1 job(s)):
     • "user-config" (L15) - Last execution time: 5s
       .github/workflows/git-user-config.yml:15

📄 .github/workflows/sync-default-branches.yml
  ✅ Safe to migrate (1 job(s)):
     • "sync" (L24) - Last execution time: 7s
       .github/workflows/sync-default-branches.yml:24

📄 .github/workflows/test.yml
  ✅ Safe to migrate (1 job(s)):
     • "test" (L15) - Last execution time: 13s
       .github/workflows/test.yml:15

📄 .github/workflows/vendor-node-modules.yml
  ⚠️  Can migrate but requires attention (1 job(s)):
     • "vendor-node-modules" (L24)
       ⚠️  Last execution time: unknown
       .github/workflows/vendor-node-modules.yml:24

📄 .github/workflows/wait-for-idle-runner.yml
  ✅ Safe to migrate (1 job(s)):
     • "syntax" (L19) - Last execution time: 5s
       .github/workflows/wait-for-idle-runner.yml:19

📄 .github/workflows/git-try-push.yml
  ✅ Safe to migrate (1 job(s)):
     • "try-push" (L16) - Last execution time: 6s
       .github/workflows/git-try-push.yml:16

📄 .github/workflows/actionlint.yml
  ❌ Cannot migrate (1 job(s)):
     • "workflow_syntax" (L29)
       ❌ uses container syntax
       .github/workflows/actionlint.yml:29
  ✨ Already using ubuntu-slim (1 job(s)):
     • "upload_sarif" (L83)
       .github/workflows/actionlint.yml:83

📄 .github/workflows/setup-commit-signing.yml
  ❌ Cannot migrate (1 job(s)):
     • "ssh-commit-signing" (L22)
       ❌ uses container syntax
       .github/workflows/setup-commit-signing.yml:22

📄 .github/workflows/create-gcloud-instance.yml
  ⚠️  Can migrate but requires attention (1 job(s)):
     • "syntax" (L19)
       ⚠️  Setup may be required (shellcheck)
       Last execution time: 4s
       .github/workflows/create-gcloud-instance.yml:19

✅ 5 job(s) can be safely migrated
⚠️  2 job(s) can be migrated but require attention
❌ 3 job(s) cannot be migrated
✨ 3 job(s) already using ubuntu-slim
📊 Total: 7 job(s) eligible for migration
```