### PR TITLE
Improve cache-homebrew-prefix action

### DIFF
--- a/.github/workflows/cache-homebrew-prefix.yml
+++ b/.github/workflows/cache-homebrew-prefix.yml
@@ -11,7 +11,7 @@ on:
 permissions: {}
 
 jobs:
-  cache-homebrew-prefix:
+  cache-homebrew-prefix-install:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -22,26 +22,71 @@ jobs:
       - name: Set up Homebrew
         uses: ./setup-homebrew/
 
-      - name: Ensure empty Homebrew
+      - name: Ensure empty Homebrew formulae
         run: |
           formulae="$(brew list --formula || true)"
           if [[ -n "${formulae}" ]]; then
             brew uninstall --force --ignore-dependencies ${formulae}
           fi
-
-          casks="$(brew list --cask 2>/dev/null || true)"
-          if [[ -n "${casks}" ]]; then
-            brew uninstall --cask --force ${casks}
-          fi
         shell: /bin/bash -euo pipefail {0}
 
-      - name: Cache Homebrew prefix
+      - name: Install pre-existing formula
+        run: brew install --formula hello
+        shell: /bin/bash -euo pipefail {0}
+
+      - name: Cache Homebrew prefix with uninstall
         uses: ./cache-homebrew-prefix/
         with:
           install: wget jq
+          uninstall: true
 
       - name: Verify installs
         run: |
+          ! brew list --formula hello >/dev/null 2>&1
+          brew list --versions wget
+          brew list --versions jq
+        shell: /bin/bash -euo pipefail {0}
+
+  cache-homebrew-prefix-brewfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Homebrew
+        uses: ./setup-homebrew/
+
+      - name: Ensure empty Homebrew formulae
+        run: |
+          formulae="$(brew list --formula || true)"
+          if [[ -n "${formulae}" ]]; then
+            brew uninstall --force --ignore-dependencies ${formulae}
+          fi
+        shell: /bin/bash -euo pipefail {0}
+
+      - name: Install pre-existing formula
+        run: brew install --formula hello
+        shell: /bin/bash -euo pipefail {0}
+
+      - name: Create Brewfile
+        run: |
+          cat > Brewfile <<'EOF'
+          brew "wget"
+          brew "jq"
+          EOF
+        shell: /bin/bash -euo pipefail {0}
+
+      - name: Cache Homebrew prefix from Brewfile with uninstall
+        uses: ./cache-homebrew-prefix/
+        with:
+          brewfile: true
+          uninstall: true
+
+      - name: Verify installs
+        run: |
+          ! brew list --formula hello >/dev/null 2>&1
           brew list --versions wget
           brew list --versions jq
         shell: /bin/bash -euo pipefail {0}

--- a/cache-homebrew-prefix/README.md
+++ b/cache-homebrew-prefix/README.md
@@ -10,12 +10,26 @@ A composite action that caches the Homebrew prefix, installs formulae via
   uses: Homebrew/actions/cache-homebrew-prefix@main
   with:
     install: wget jq
+    uninstall: true
+```
+
+```yaml
+- name: Cache Homebrew prefix from Brewfile
+  uses: Homebrew/actions/cache-homebrew-prefix@main
+  with:
+    brewfile: true
+    uninstall: true
 ```
 
 ## Inputs
 
-- `install` (required): Formula names passed to `brew install --formula`.
+- `install` (optional): Formula names passed to `brew install --formula`.
   Tokens are split on whitespace and must match `^[A-Za-z0-9._/@-]+$`.
+- `brewfile` (optional): Install formulae from `./Brewfile` instead of
+  `install` using `brew bundle --file Brewfile --no-upgrade`. Default: `false`.
+- `uninstall` (optional): When `true`, existing formulae are automatically
+  removed before install. Default: `false`.
+- Validation: Either `install` or `brewfile` must be provided (but not both).
 
 ## Outputs
 
@@ -24,7 +38,11 @@ A composite action that caches the Homebrew prefix, installs formulae via
 
 ## Notes
 
-- The action fails early if any formulae or casks are already installed.
-  Ensure the runner has an empty Homebrew before running this action.
+- The action only checks existing formulae (not casks).
+- If formulae are already installed and `uninstall` is `false`, the action
+  fails early.
+- If `uninstall` is `true`, existing formulae are cleaned up with
+  `brew test-bot --only-cleanup-before` before install.
+- `brewfile` and `install` are mutually exclusive.
 - Cache keys are based on `brew list --formula --versions` and are scoped by
   OS version and architecture.

--- a/cache-homebrew-prefix/action.yml
+++ b/cache-homebrew-prefix/action.yml
@@ -2,8 +2,17 @@ name: Cache Homebrew Prefix
 description: Cache Homebrew prefix and install formulae.
 inputs:
   install:
-    description: Arguments passed to `brew install --formula`.
-    required: true
+    description: Formula names passed to `brew install --formula`.
+    required: false
+    default: ""
+  brewfile:
+    description: Install formulae from `./Brewfile` instead of `install`.
+    required: false
+    default: "false"
+  uninstall:
+    description: Automatically uninstall existing formulae before installing.
+    required: false
+    default: "false"
 outputs:
   prefix:
     description: Homebrew prefix path.
@@ -14,17 +23,30 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Ensure Homebrew is empty
+    - name: Handle existing Homebrew formulae
       run: |
         installed_formulae="$(brew list --formula 2>/dev/null || true)"
-        installed_casks="$(brew list --cask 2>/dev/null || true)"
-        installed="$(printf '%s\n%s' "${installed_formulae}" "${installed_casks}" | sed '/^$/d')"
-        if [[ -n "${installed}" ]]; then
-          echo "::error::Homebrew already has packages installed. Ensure no packages installed before this action." >&2
-          echo "${installed}" >&2
+        if [[ -z "${installed_formulae}" ]]; then
+          exit 0
+        fi
+
+        if [[ "${UNINSTALL}" != "true" ]]; then
+          echo "::error::Homebrew already has formulae installed. Set with.uninstall=true to remove them automatically." >&2
+          echo "${installed_formulae}" >&2
+          exit 1
+        fi
+
+        brew test-bot --only-cleanup-before
+
+        remaining_formulae="$(brew list --formula 2>/dev/null || true)"
+        if [[ -n "${remaining_formulae}" ]]; then
+          echo "::error::brew test-bot cleanup did not remove all formulae." >&2
+          echo "${remaining_formulae}" >&2
           exit 1
         fi
       shell: /bin/bash -euo pipefail {0}
+      env:
+        UNINSTALL: ${{ inputs.uninstall }}
 
     - name: Resolve Homebrew prefix
       id: prefix
@@ -65,11 +87,25 @@ runs:
         restore-keys: |
           homebrew-prefix-${{ steps.cache-prefix.outputs.prefix }}-
 
-    - name: Install Homebrew packages
+    - name: Install Homebrew formulae
       run: |
-        read -r -a raw_args <<< "${INSTALL}"
+        if [[ "${BREWFILE}" = "true" ]]; then
+          if [[ -n "${INSTALL//[[:space:]]/}" ]]; then
+            echo "Cannot use both brewfile=true and install input." >&2
+            exit 1
+          fi
+          if [[ ! -f Brewfile ]]; then
+            echo "Brewfile not found in current directory." >&2
+            exit 1
+          fi
+          brew bundle --file Brewfile --no-upgrade
+          exit 0
+        else
+          raw_args="${INSTALL}"
+        fi
+
         args=()
-        for token in "${raw_args[@]}"; do
+        for token in ${raw_args}; do
           if [[ "${token}" = -* ]]; then
             echo "Options are not allowed in install list: ${token}" >&2
             exit 1
@@ -88,6 +124,7 @@ runs:
       shell: /bin/bash -euo pipefail {0}
       env:
         INSTALL: ${{ inputs.install }}
+        BREWFILE: ${{ inputs.brewfile }}
 
     - name: Compute Homebrew cache key
       id: cache-key


### PR DESCRIPTION
- Add option to uninstall existing formulae before installing new ones by calling `brew test-bot --only-cleanup-before`
- Add option to install formulae from a `Brewfile`