### PR TITLE
Homebrew/setup-ruby: add working-directory input

### DIFF
--- a/.github/workflows/setup-ruby.yml
+++ b/.github/workflows/setup-ruby.yml
@@ -72,6 +72,11 @@ jobs:
             test "${RUBY_PREFIX}" = "$(brew --prefix ruby)"
           fi
 
+      - name: Set up Ruby from subdirectory
+        uses: ./setup-ruby/
+        with:
+          working-directory: setup-ruby
+
   bundler-cache:
     strategy:
       fail-fast: false

--- a/setup-ruby/README.md
+++ b/setup-ruby/README.md
@@ -44,6 +44,16 @@ Enable Bundler cache:
     bundler-cache: true
 ```
 
+Run from a specific subdirectory:
+
+```yaml
+- name: Set up Ruby from subdirectory
+  uses: Homebrew/actions/setup-ruby@main
+  with:
+    setup-homebrew: true
+    working-directory: path/to/project
+```
+
 ## Outputs
 
 - `ruby-path`: Path to the Ruby executable.
@@ -61,3 +71,4 @@ Enable Bundler cache:
   - Requires `Gemfile` in the current working directory.
   - Uses `Gemfile.lock` for cache hashing when present, otherwise falls back to `Gemfile`.
   - Includes Ruby version and Ruby prefix in cache key derivation.
+- `working-directory` defaults to `.` and is used for Ruby setup, Gemfile discovery, and Bundler commands.

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Cache gems and run `bundle install` only when needed
     required: false
     default: false
+  working-directory:
+    description: Working directory to run this action in
+    required: false
+    default: .
   debug:
     description: Show debugging output
     required: false
@@ -43,6 +47,7 @@ runs:
     - name: Set up Ruby
       id: setup
       shell: /bin/bash -euo pipefail {0}
+      working-directory: ${{ inputs.working-directory }}
       env:
         PORTABLE_RUBY: ${{ inputs.portable-ruby }}
         DEBUG: ${{ inputs.debug }}
@@ -101,6 +106,7 @@ runs:
       if: inputs.bundler-cache == 'true'
       id: bundler-cache-config
       shell: /bin/bash -euo pipefail {0}
+      working-directory: ${{ inputs.working-directory }}
       env:
         PORTABLE_RUBY: ${{ inputs.portable-ruby }}
         RUBY_VERSION: ${{ steps.setup.outputs.ruby-version }}
@@ -124,7 +130,7 @@ runs:
           ruby_prefix_hash="$(printf '%s' "${RUBY_PREFIX}" | shasum -a 256 | awk '{print $1}')"
         fi
 
-        bundle_path="${GITHUB_WORKSPACE}/vendor/bundle"
+        bundle_path="$(pwd)/vendor/bundle"
         cache_prefix="setup-ruby-${RUNNER_OS}-${RUNNER_ARCH}-${RUBY_VERSION}-${PORTABLE_RUBY}-${ruby_prefix_hash}"
 
         echo "bundle-path=${bundle_path}" >> "${GITHUB_OUTPUT}"
@@ -143,6 +149,7 @@ runs:
     - name: Install Bundler gems
       if: inputs.bundler-cache == 'true'
       shell: /bin/bash -euo pipefail {0}
+      working-directory: ${{ inputs.working-directory }}
       env:
         BUNDLE_PATH: ${{ steps.bundler-cache-config.outputs.bundle-path }}
       run: |


### PR DESCRIPTION
This allows the `Gemfile` to be located in a subdirectory of the repository.