### PR TITLE
cache-homebrew-prefix: restore git state after prefix cache restore

### DIFF
--- a/cache-homebrew-prefix/action.yml
+++ b/cache-homebrew-prefix/action.yml
@@ -83,8 +83,11 @@ runs:
       run: |
         brew_repo="$(brew --repository)"
         if [[ -d "${brew_repo}/.git" ]]; then
-          echo "sha=$(git -C "${brew_repo}" rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
-          echo "repo=${brew_repo}" >> "${GITHUB_OUTPUT}"
+          sha="$(git -C "${brew_repo}" rev-parse HEAD 2>/dev/null || true)"
+          if [[ -n "${sha}" ]]; then
+            echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
+            echo "repo=${brew_repo}" >> "${GITHUB_OUTPUT}"
+          fi
         fi
       shell: /bin/bash -euo pipefail {0}
 


### PR DESCRIPTION
## Summary

The `cache-homebrew-prefix` action caches the entire Homebrew prefix directory (including `.git`) via `actions/cache/restore`. When the cached snapshot was saved during a previous CI run on a different branch (typically `main`), restoring it silently resets the Homebrew repository to that branch — discarding the current checkout (e.g. a PR's merge commit).

This causes two problems for consumers:
1. **Test-bot runs the wrong code** — it tests the cached `main` snapshot instead of the PR.
2. **New files from the PR appear as untracked modifications**, causing `brew doctor` (via `brew test-bot --only-setup`) to fail with:
   ```
   Error: You have uncommitted modifications to Homebrew/brew.
   ```

### Fix

Save the git `HEAD` sha before the cache restore and re-checkout it afterwards if the restore changed it. The new steps are a no-op when the cache doesn't affect `.git` (the `if` condition and sha comparison both guard against unnecessary work).

### Instance of the failure

See [this failing build](https://github.com/Homebrew/brew/actions/runs/22231823509/job/64313526363?pr=21603) from Homebrew/brew PR #21603 for a specific example.

Replaces the workaround in https://github.com/Homebrew/brew/pull/21604 which applied the same fix inline in `tests.yml`.