### PR TITLE
cache-homebrew-prefix: use `brew bundle check`.

### DIFF
--- a/cache-homebrew-prefix/README.md
+++ b/cache-homebrew-prefix/README.md
@@ -26,7 +26,9 @@ A composite action that caches the Homebrew prefix, installs formulae via
 - `install` (optional): Formula names passed to `brew install --formula`.
   Tokens are split on whitespace and must match `^[A-Za-z0-9._/@-]+$`.
 - `brewfile` (optional): Install formulae from `./Brewfile` instead of
-  `install` using `brew bundle --file Brewfile --no-upgrade`. Default: `false`.
+  `install`. Runs `brew bundle check --file Brewfile` first and only runs
+  `brew bundle --file Brewfile --no-upgrade` if dependencies are missing.
+  Default: `false`.
 - `uninstall` (optional): When `true`, existing formulae are automatically
   removed before install. Default: `false`.
 - Validation: Either `install` or `brewfile` must be provided (but not both).

--- a/cache-homebrew-prefix/action.yml
+++ b/cache-homebrew-prefix/action.yml
@@ -124,7 +124,11 @@ runs:
             echo "Brewfile not found in current directory." >&2
             exit 1
           fi
-          brew bundle --file Brewfile --no-upgrade
+          if brew bundle check --file Brewfile; then
+            echo "Brewfile dependencies are already installed."
+          else
+            brew bundle --file Brewfile --no-upgrade
+          fi
           exit 0
         else
           raw_args="${INSTALL}"


### PR DESCRIPTION
This can avoid unnecessary installs or just slow `brew bundle` runs.