### PR TITLE
wait-for-idle-runner: fix ERR_PACKAGE_PATH_NOT_EXPORTED

### DIFF
--- a/wait-for-idle-runner/main.js
+++ b/wait-for-idle-runner/main.js
@@ -1,5 +1,5 @@
-const core = require('@actions/core')
-const github = require('@actions/github')
+import * as core from '@actions/core'
+import * as github from '@actions/github'
 
 const NUMBER_OF_ATTEMPTS = 300
 const TIME_BETWEEN_ATTEMPTS_SECONDS = 60

--- a/wait-for-idle-runner/package.json
+++ b/wait-for-idle-runner/package.json
@@ -1,4 +1,5 @@
 {
   "name": "wait-for-idle-runner",
+  "type": "module",
   "main": "main.js"
 }


### PR DESCRIPTION
Fix `wait-for-idle-runner` for Node 20 with the current toolkit packages.

ref:
https://github.com/Homebrew/homebrew-core/actions/runs/22648574355/job/65642419919

```
node:internal/modules/cjs/loader:645
      throw e;
      ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /home/runner/work/_actions/Homebrew/actions/main/node_modules/@actions/core/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:322:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:613:13)
    at resolveExports (node:internal/modules/cjs/loader:638:36)
    at Module._findPath (node:internal/modules/cjs/loader:711:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1193:27)
    at Module._load (node:internal/modules/cjs/loader:1038:27)
    at Module.require (node:internal/modules/cjs/loader:1289:19)
    at require (node:internal/modules/helpers:182:18)
    at Object.<anonymous> (/home/runner/work/_actions/Homebrew/actions/main/wait-for-idle-runner/main.js:1:14)
    at Module._compile (node:internal/modules/cjs/loader:1521:14) ***
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
***
```
