### PR TITLE
cache-homebrew-prefix: scope caches by workflow

### DIFF
--- a/.github/workflows/cache-homebrew-prefix.yml
+++ b/.github/workflows/cache-homebrew-prefix.yml
@@ -35,10 +35,23 @@ jobs:
         shell: /bin/bash -euo pipefail {0}
 
       - name: Cache Homebrew prefix with uninstall
+        id: cache-homebrew-prefix-install
         uses: ./cache-homebrew-prefix/
         with:
           install: wget jq
           uninstall: true
+          workflow-key: test
+
+      - name: Verify cache metadata
+        run: |
+          . /etc/os-release
+          expected_prefix="${ID}-${VERSION_ID}-$(uname -m)-test"
+          test "${CACHE_PREFIX}" = "${expected_prefix}"
+          test -n "${CACHE_KEY}"
+        shell: /bin/bash -euo pipefail {0}
+        env:
+          CACHE_PREFIX: ${{ steps.cache-homebrew-prefix-install.outputs.cache-prefix }}
+          CACHE_KEY: ${{ steps.cache-homebrew-prefix-install.outputs.cache-key }}
 
       - name: Verify installs
         run: |
@@ -79,10 +92,23 @@ jobs:
         shell: /bin/bash -euo pipefail {0}
 
       - name: Cache Homebrew prefix from Brewfile with uninstall
+        id: cache-homebrew-prefix-brewfile
         uses: ./cache-homebrew-prefix/
         with:
           brewfile: true
           uninstall: true
+          workflow-key: brewfile-test
+
+      - name: Verify cache metadata
+        run: |
+          . /etc/os-release
+          expected_prefix="${ID}-${VERSION_ID}-$(uname -m)-brewfile-test"
+          test "${CACHE_PREFIX}" = "${expected_prefix}"
+          test -n "${CACHE_KEY}"
+        shell: /bin/bash -euo pipefail {0}
+        env:
+          CACHE_PREFIX: ${{ steps.cache-homebrew-prefix-brewfile.outputs.cache-prefix }}
+          CACHE_KEY: ${{ steps.cache-homebrew-prefix-brewfile.outputs.cache-key }}
 
       - name: Verify installs
         run: |

--- a/cache-homebrew-prefix/README.md
+++ b/cache-homebrew-prefix/README.md
@@ -11,6 +11,7 @@ A composite action that caches the Homebrew prefix, installs formulae via
   with:
     install: wget jq
     uninstall: true
+    workflow-key: actionlint
 ```
 
 ```yaml
@@ -25,6 +26,10 @@ A composite action that caches the Homebrew prefix, installs formulae via
 
 - `install` (optional): Formula names passed to `brew install --formula`.
   Tokens are split on whitespace and must match `^[A-Za-z0-9._/@-]+$`.
+- `workflow-key` (optional): Stable namespace appended to the cache prefix so
+  multiple workflows in the same repository can keep separate caches. For
+  example, set `workflow-key: ${{ github.workflow }}` or a custom value like
+  `actionlint`. Characters outside `[A-Za-z0-9._-]` are normalized to `-`.
 - `brewfile` (optional): Install formulae from `./Brewfile` instead of
   `install`. Runs `brew bundle check --file Brewfile` first and only runs
   `brew bundle --file Brewfile --no-upgrade` if dependencies are missing.
@@ -36,6 +41,8 @@ A composite action that caches the Homebrew prefix, installs formulae via
 ## Outputs
 
 - `prefix`: Homebrew prefix path used for caching.
+- `cache-prefix`: The computed cache prefix, including OS, architecture, and
+  any `workflow-key`.
 - `cache-key`: The computed cache key hash.
 
 ## Notes
@@ -47,4 +54,6 @@ A composite action that caches the Homebrew prefix, installs formulae via
   `brew test-bot --only-cleanup-before` before install.
 - `brewfile` and `install` are mutually exclusive.
 - Cache keys are based on `brew list --formula --versions` and are scoped by
-  OS version and architecture.
+  OS version, architecture, and optional `workflow-key`.
+- The action restores the newest matching cache for the computed prefix, then
+  only saves when the final exact cache key does not already exist.

--- a/cache-homebrew-prefix/action.yml
+++ b/cache-homebrew-prefix/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: Formula names passed to `brew install --formula`.
     required: false
     default: ""
+  workflow-key:
+    description: Stable namespace appended to the cache prefix to isolate caches between workflows.
+    required: false
+    default: ""
   brewfile:
     description: Install formulae from `./Brewfile` instead of `install`.
     required: false
@@ -17,6 +21,9 @@ outputs:
   prefix:
     description: Homebrew prefix path.
     value: ${{ steps.prefix.outputs.path }}
+  cache-prefix:
+    description: Cache key prefix derived from runner details and optional workflow key.
+    value: ${{ steps.cache-prefix.outputs.prefix }}
   cache-key:
     description: Cache key derived from formula list.
     value: ${{ steps.cache-key.outputs.key }}
@@ -76,8 +83,20 @@ runs:
         else
           cache_key_prefix="${RUNNER_OS}-${arch}"
         fi
+
+        if [[ -n "${WORKFLOW_KEY}" ]]; then
+          sanitized_workflow_key="$(printf '%s' "${WORKFLOW_KEY}" | tr '\r\n' '  ' | sed -E 's/[^A-Za-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+          if [[ -z "${sanitized_workflow_key}" ]]; then
+            echo "workflow-key must contain at least one letter, number, '.', '_' or '-'." >&2
+            exit 1
+          fi
+          cache_key_prefix="${cache_key_prefix}-${sanitized_workflow_key}"
+        fi
+
         echo "prefix=${cache_key_prefix}" >> "${GITHUB_OUTPUT}"
       shell: /bin/bash -euo pipefail {0}
+      env:
+        WORKFLOW_KEY: ${{ inputs.workflow-key }}
 
     - name: Save Homebrew repository git HEAD
       id: save-git-head
@@ -171,8 +190,16 @@ runs:
         echo "key=${key}" >> "${GITHUB_OUTPUT}"
       shell: /bin/bash -euo pipefail {0}
 
+    - name: Check for exact Homebrew cache
+      id: cache-lookup
+      uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      with:
+        path: ${{ steps.prefix.outputs.path }}
+        key: homebrew-prefix-${{ steps.cache-prefix.outputs.prefix }}-${{ steps.cache-key.outputs.key }}
+        lookup-only: true
+
     - name: Save Homebrew prefix cache
-      if: steps.cache-restore.outputs.cache-matched-key != format('homebrew-prefix-{0}-{1}', steps.cache-prefix.outputs.prefix, steps.cache-key.outputs.key)
+      if: steps.cache-lookup.outputs.cache-hit != 'true'
       uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ steps.prefix.outputs.path }}


### PR DESCRIPTION
- add an optional workflow-key namespace and cache-prefix output
- skip cache saves only when the exact final key already exists
- sanitize workflow-key values safely and cover the new behavior in docs/tests

Should fix regression from https://github.com/Homebrew/actions/pull/804 where the cache is not always being saved correctly as well as allowing us to use multiple caches properly in Homebrew/brew.