### PR TITLE
Warn `@master` users to migrate to `@main`

### DIFF
--- a/api-commit-and-push/main.mts
+++ b/api-commit-and-push/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("api-commit-and-push")
 import * as core from "@actions/core"
 import * as github from "@actions/github"
 import { getExecOutput } from "@actions/exec"

--- a/bump-formulae/action.yml
+++ b/bump-formulae/action.yml
@@ -14,6 +14,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Deprecation warning for master branch
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/../deprecate-master.sh" bump-formulae
+
     - run: echo "::warning::Homebrew/actions/bump-formulae is deprecated. Please use Homebrew/actions/bump-packages instead."
       shell: sh
 

--- a/bump-packages/action.yml
+++ b/bump-packages/action.yml
@@ -23,6 +23,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Deprecation warning for master branch
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/../deprecate-master.sh" bump-packages
+
     - name: Bump formulae
       run: |
         if [[ "$INPUT_FORK" == "true" ]]; then

--- a/cache-homebrew-prefix/action.yml
+++ b/cache-homebrew-prefix/action.yml
@@ -30,6 +30,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Deprecation warning for master branch
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/../deprecate-master.sh" cache-homebrew-prefix
+
     - name: Handle existing Homebrew formulae
       run: |
         installed_formulae="$(brew list --formula 2>/dev/null || true)"

--- a/check-commit-format/main.mts
+++ b/check-commit-format/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("check-commit-format")
 import assert from "node:assert/strict"
 import * as core from "@actions/core"
 import * as github from "@actions/github"

--- a/create-gcloud-instance/action.yaml
+++ b/create-gcloud-instance/action.yaml
@@ -32,6 +32,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Deprecation warning for master branch
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/../deprecate-master.sh" create-gcloud-instance
+
     - run: "$GITHUB_ACTION_PATH/create-gcloud-instance.sh"
       shell: bash
       env:

--- a/create-or-update-issue/main.mts
+++ b/create-or-update-issue/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("create-or-update-issue")
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 

--- a/create-pull-request/main.mts
+++ b/create-pull-request/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("create-pull-request")
 import * as core from "@actions/core"
 import * as github from "@actions/github"
 

--- a/deprecate-master.mts
+++ b/deprecate-master.mts
@@ -1,0 +1,14 @@
+// Warn users referencing Homebrew/actions via @master to migrate to @main.
+// Called from TypeScript actions with the action name as the sole argument.
+import * as core from "@actions/core"
+
+export function deprecateMaster(action: string) {
+  if (process.env.GITHUB_ACTION_REF === "master") {
+    core.warning(
+      `Homebrew/actions/${action}@master is deprecated. ` +
+      `Please update your workflow references to use Homebrew/actions/${action}@main. ` +
+      `The "master" branch sync will stop and this warning will become ` +
+      `an error when Homebrew 5.2.0 is released (no earlier than 2026-06-10).`
+    )
+  }
+}

--- a/deprecate-master.sh
+++ b/deprecate-master.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Warn users referencing Homebrew/actions via @master to migrate to @main.
+# Called from composite actions with the action name as the sole argument.
+
+set -euo pipefail
+
+if [ -z "${GITHUB_ACTION_REF+x}" ]; then
+  echo "::error::GITHUB_ACTION_REF is not set. This script must be run inside a GitHub Actions workflow."
+  exit 1
+fi
+
+if [ "$GITHUB_ACTION_REF" = "master" ]; then
+  echo "::warning::Homebrew/actions/${1}@master is deprecated. Please update your workflow references to use Homebrew/actions/${1}@main. The 'master' branch sync will stop and this warning will become an error when Homebrew 5.2.0 is released (no earlier than 2026-06-10)."
+fi

--- a/dismiss-approvals/main.mts
+++ b/dismiss-approvals/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("dismiss-approvals")
 import * as core from "@actions/core"
 import * as github from "@actions/github"
 

--- a/failures-summary-and-bottle-result/action.yml
+++ b/failures-summary-and-bottle-result/action.yml
@@ -21,6 +21,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Deprecation warning for master branch
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/../deprecate-master.sh" failures-summary-and-bottle-result
+
     - run: |
         if [[ -f "$GITHUB_STEP_SUMMARY" ]] &&
            [[ ! -w "$GITHUB_STEP_SUMMARY" ]]

--- a/find-related-workflow-run-id/main.mts
+++ b/find-related-workflow-run-id/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("find-related-workflow-run-id")
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 

--- a/git-try-push/main.mts
+++ b/git-try-push/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("git-try-push")
 import * as core from "@actions/core"
 import { exec } from "@actions/exec"
 

--- a/git-user-config/main.mts
+++ b/git-user-config/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("git-user-config")
 import * as core from "@actions/core"
 import * as github from "@actions/github"
 import { exec } from "@actions/exec"

--- a/label-pull-requests/main.mts
+++ b/label-pull-requests/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("label-pull-requests")
 import assert from "node:assert/strict"
 import * as core from "@actions/core"
 import * as github from "@actions/github"

--- a/limit-pull-requests/main.mts
+++ b/limit-pull-requests/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("limit-pull-requests")
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 

--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -21,6 +21,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Deprecation warning for master branch
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/../deprecate-master.sh" post-build
+
     - name: Failures summary for brew test-bot
       if: always()
       uses: Homebrew/actions/failures-summary-and-bottle-result@main

--- a/post-comment/main.mts
+++ b/post-comment/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("post-comment")
 import * as core from "@actions/core"
 import * as github from "@actions/github"
 

--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -15,6 +15,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Deprecation warning for master branch
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/../deprecate-master.sh" pre-build
+
     - name: Set up Homebrew
       id: set-up-homebrew
       uses: Homebrew/actions/setup-homebrew@main

--- a/remove-disabled-packages/action.yml
+++ b/remove-disabled-packages/action.yml
@@ -10,6 +10,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Deprecation warning for master branch
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/../deprecate-master.sh" remove-disabled-packages
+
     - run: brew ruby "$GITHUB_ACTION_PATH/main.rb"
       id: remove-packages
       shell: bash

--- a/setup-commit-signing/action.yml
+++ b/setup-commit-signing/action.yml
@@ -16,6 +16,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Deprecation warning for master branch
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/../deprecate-master.sh" setup-commit-signing
+
     - name: Enable SSH agent
       run: | # zizmor: ignore[github-env]
         eval $(ssh-agent)

--- a/setup-homebrew/main.mts
+++ b/setup-homebrew/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("setup-homebrew")
 import { exec } from "@actions/exec"
 import * as core from "@actions/core"
 

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -38,6 +38,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Deprecation warning for master branch
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/../deprecate-master.sh" setup-ruby
+
     - name: Set up Homebrew
       if: inputs.setup-homebrew == 'true'
       uses: Homebrew/actions/setup-homebrew@main

--- a/wait-for-idle-runner/main.mts
+++ b/wait-for-idle-runner/main.mts
@@ -1,3 +1,5 @@
+import { deprecateMaster } from "../deprecate-master.mts"
+deprecateMaster("wait-for-idle-runner")
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 


### PR DESCRIPTION
- External workflows still reference `@master`; GitHub Actions does not auto-redirect after a branch rename
- The `master` branch sync will stop and this warning will become an error in Homebrew 5.2.0 (no earlier than 2026-06-10)
- Shared `deprecate-master.{mts,sh}` keep the message in one place across all 23 actions

See also https://github.com/Homebrew/brew/pull/21937

Code written with Claude Claude, several local review and edit passes.