### PR TITLE
setup-commit-signing: fix getting user email

### DIFF
--- a/setup-commit-signing/main.sh
+++ b/setup-commit-signing/main.sh
@@ -12,7 +12,7 @@ ssh-add -q - <<< "${SSH_SIGNING_KEY}"
 
 # add our public key as an allowed signer
 # we treat the public key as trusted for the currently configured git email
-allowed_signer="$(git config get user.email) ${pubkey}"
+allowed_signer="$(git config --global user.email) ${pubkey}"
 mkdir -p ~/.ssh
 echo "${allowed_signer}" >> ~/.ssh/allowed_signers
 


### PR DESCRIPTION
We set `user.email` with `git config --global` in the git-user-config action, so let's retrieve it with `git config --global` instead of `git config get` to avoid getting the `fatal: not in a git directory` error on older Git versions.

Fixes recent bottle publish failures in homebrew/core. Ubuntu PPAs are currently experiencing issues, so we end up installing an outdated version of Git in the Docker image. That problem will be addressed in Homebrew/brew.