### PR TITLE
Tweak setup-ruby bundler cache

### DIFF
--- a/setup-ruby/README.md
+++ b/setup-ruby/README.md
@@ -65,10 +65,11 @@ Run from a specific subdirectory:
 - When `portable-ruby` is `false`, this action installs Homebrew's `ruby` formula (if needed) and adds it to `PATH`.
 - When `portable-ruby` is `true`, this action uses the same Ruby Homebrew runs (`brew ruby`) and adds it to `PATH`.
 - `setup-homebrew` defaults to `false` and only runs `Homebrew/actions/setup-homebrew` when explicitly enabled.
+- When `Gemfile` is present, this action runs `bundle check` and runs `bundle install --jobs 4 --retry 3` only when needed.
 - `bundler-cache` defaults to `false`. When enabled, this action:
   - Caches `vendor/bundle` using `actions/cache`.
-  - Runs `bundle install` only when `bundle check` fails.
+  - Configures Bundler to install gems to `vendor/bundle`.
   - Requires `Gemfile` in the current working directory.
   - Uses `Gemfile.lock` for cache hashing when present, otherwise falls back to `Gemfile`.
-  - Includes Ruby version and Ruby prefix in cache key derivation.
+  - Includes Ruby version, portable Ruby mode and Ruby prefix in cache key derivation.
 - `working-directory` defaults to `.` and is used for Ruby setup, Gemfile discovery, and Bundler commands.

--- a/setup-ruby/action.test.mts
+++ b/setup-ruby/action.test.mts
@@ -1,0 +1,141 @@
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import yaml from "js-yaml";
+
+type Step = {
+  name: string;
+  if?: string;
+  run?: string;
+  env?: Record<string, string>;
+};
+
+type Action = {
+  runs: {
+    steps: Step[];
+  };
+};
+
+const action = yaml.load(
+  fs.readFileSync(new URL("action.yml", import.meta.url), "utf8"),
+) as Action;
+
+function actionStep(name: string): Step {
+  const step = action.runs.steps.find((candidate) => candidate.name === name);
+  assert.ok(step, `Expected ${name} step to exist.`);
+  return step;
+}
+
+function bundleCalls(bundlerCache: string, bundleCheckStatus = "1"): { calls: string[]; bundlePath: string } {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "setup-ruby-"));
+
+  try {
+    const bin = path.join(directory, "bin");
+    const log = path.join(directory, "bundle.log");
+    const bundlePath = path.join(directory, "vendor/bundle");
+
+    fs.mkdirSync(bin);
+    fs.writeFileSync(path.join(directory, "Gemfile"), "source 'https://rubygems.org'\n");
+    fs.writeFileSync(path.join(bin, "bundle"), [
+      "#!/bin/sh",
+      "printf '%s\\n' \"$*\" >> \"$BUNDLE_LOG\"",
+      "if [ \"$1\" = \"check\" ]; then",
+      "  exit \"$BUNDLE_CHECK_STATUS\"",
+      "fi",
+    ].join("\n"));
+    fs.chmodSync(path.join(bin, "bundle"), 0o755);
+
+    execFileSync("/bin/bash", ["-e", "-u", "-o", "pipefail", "-c", actionStep("Install Bundler gems").run!], {
+      cwd: directory,
+      env: {
+        ...process.env,
+        BUNDLE_CHECK_STATUS: bundleCheckStatus,
+        BUNDLE_LOG: log,
+        BUNDLE_PATH: bundlePath,
+        BUNDLER_CACHE: bundlerCache,
+        PATH: `${bin}:${process.env.PATH}`,
+      },
+    });
+
+    return { calls: fs.readFileSync(log, "utf8").trimEnd().split("\n"), bundlePath };
+  } finally {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+describe("setup-ruby action", () => {
+  it("runs bundle install without requiring Bundler cache", () => {
+    const installStep = actionStep("Install Bundler gems");
+
+    assert.equal(installStep.if, undefined);
+    assert.deepEqual(bundleCalls("false").calls, [
+      "check",
+      "install --jobs 4 --retry 3",
+    ]);
+  });
+
+  it("skips bundle install when bundle check succeeds", () => {
+    assert.deepEqual(bundleCalls("false", "0").calls, ["check"]);
+  });
+
+  it("configures the Bundler path before installing with Bundler cache", () => {
+    const result = bundleCalls("true");
+
+    assert.deepEqual(result.calls, [
+      `config set --local path ${result.bundlePath}`,
+      "check",
+      "install --jobs 4 --retry 3",
+    ]);
+  });
+
+  it("keys the Bundler cache by Ruby version", () => {
+    const configureStep = actionStep("Configure Bundler cache");
+
+    assert.equal(configureStep.env?.RUBY_VERSION, "${{ steps.setup.outputs.ruby-version }}");
+    assert.match(configureStep.run!, /cache_prefix=.*\$\{RUBY_VERSION\}/);
+  });
+
+  it("keys the Bundler cache by portable Ruby mode", () => {
+    const configureStep = actionStep("Configure Bundler cache");
+
+    assert.match(actionStep("Set up Ruby").run!, /portable-ruby=\$\{portable_ruby\}/);
+    assert.equal(configureStep.env?.PORTABLE_RUBY, "${{ steps.setup.outputs.portable-ruby }}");
+    assert.match(configureStep.run!, /cache_prefix=.*\$\{PORTABLE_RUBY\}/);
+  });
+
+  it("keys the Bundler cache by Gemfile.lock when present", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "setup-ruby-"));
+
+    try {
+      const gemfile = "source 'https://rubygems.org'\ngem 'rake'\n";
+      const gemfileLock = "lockfile contents\n";
+      const githubOutput = path.join(directory, "github-output");
+
+      fs.writeFileSync(path.join(directory, "Gemfile"), gemfile);
+      fs.writeFileSync(path.join(directory, "Gemfile.lock"), gemfileLock);
+
+      execFileSync("/bin/bash", ["-e", "-u", "-o", "pipefail", "-c", actionStep("Configure Bundler cache").run!], {
+        cwd: directory,
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: githubOutput,
+          PORTABLE_RUBY: "false",
+          RUBY_PREFIX: "/opt/homebrew/opt/ruby",
+          RUBY_VERSION: "3.4.1",
+          RUNNER_ARCH: "ARM64",
+          RUNNER_OS: "macOS",
+        },
+      });
+
+      assert.ok(
+        Object.fromEntries(
+          fs.readFileSync(githubOutput, "utf8").trimEnd().split("\n").map((line) => line.split("=", 2)),
+        )["cache-key"].endsWith(crypto.createHash("sha256").update(gemfileLock).digest("hex")),
+      );
+    } finally {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+});

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: false
   bundler-cache:
-    description: Cache gems and run `bundle install` only when needed
+    description: Cache gems installed by `bundle install`
     required: false
     default: false
   working-directory:
@@ -76,6 +76,7 @@ runs:
         case "${portable_ruby_input}" in
           true|1|yes|y) portable_ruby=true ;;
         esac
+        echo "portable-ruby=${portable_ruby}" >> "${GITHUB_OUTPUT}"
 
         if [[ "${portable_ruby}" == "true" ]]; then
           ruby_path="$(brew --repository)/Library/Homebrew/vendor/portable-ruby/current/bin/ruby"
@@ -113,7 +114,7 @@ runs:
       shell: /bin/bash -euo pipefail {0}
       working-directory: ${{ inputs.working-directory }}
       env:
-        PORTABLE_RUBY: ${{ inputs.portable-ruby }}
+        PORTABLE_RUBY: ${{ steps.setup.outputs.portable-ruby }}
         RUBY_VERSION: ${{ steps.setup.outputs.ruby-version }}
         RUBY_PREFIX: ${{ steps.setup.outputs.ruby-prefix }}
       run: |
@@ -127,7 +128,7 @@ runs:
           hash_source="Gemfile.lock"
         fi
 
-        if command -v sha256sum >/dev/null 2>&1; then
+        if command -v sha256sum &>/dev/null; then
           source_hash="$(sha256sum "${hash_source}" | awk '{print $1}')"
           ruby_prefix_hash="$(printf '%s' "${RUBY_PREFIX}" | sha256sum | awk '{print $1}')"
         else
@@ -152,13 +153,20 @@ runs:
         restore-keys: ${{ steps.bundler-cache-config.outputs.restore-key }}
 
     - name: Install Bundler gems
-      if: inputs.bundler-cache == 'true'
       shell: /bin/bash -euo pipefail {0}
       working-directory: ${{ inputs.working-directory }}
       env:
+        BUNDLER_CACHE: ${{ inputs.bundler-cache }}
         BUNDLE_PATH: ${{ steps.bundler-cache-config.outputs.bundle-path }}
       run: |
-        bundle config set --local path "${BUNDLE_PATH}"
+        if [[ ! -f "Gemfile" ]]; then
+          exit 0
+        fi
+
+        if [[ "${BUNDLER_CACHE}" == "true" ]]; then
+          bundle config set --local path "${BUNDLE_PATH}"
+        fi
+
         if ! bundle check; then
           bundle install --jobs 4 --retry 3
         fi


### PR DESCRIPTION
- Keep `bundle install` available without `bundler-cache` so Gemfile projects still verify dependencies.
- Key cached gems by Ruby version and resolved portable Ruby mode to avoid reusing incompatible installs.
- Preserve `bundle check` so warm dependency sets skip needless installs.