### PR TITLE
Add tests for untested actions

### DIFF
--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -1,0 +1,114 @@
+name: Test remove disabled packages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    paths:
+      - "**remove-disabled-packages**"
+      - "deprecate-master.sh"
+      - "package.json"
+      - "package-lock.json"
+      - "node_modules/**"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_ENV_HINTS: 1
+  # Point the action at a throwaway fixture tap instead of this repository.
+  GITHUB_REPOSITORY: Homebrew/actions-test-tap
+
+jobs:
+  remove-disabled-packages:
+    if: github.repository_owner == 'Homebrew'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/homebrew/brew:main
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          core: false
+          cask: false
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Create fixture tap
+        id: fixture
+        run: |
+          git config --global user.name BrewTestBot
+          git config --global user.email no-reply@brew.sh
+
+          tap_dir="$(brew --repository "${GITHUB_REPOSITORY}")"
+          git config --global --add safe.directory "${tap_dir}"
+          mkdir -p "${tap_dir}/Formula"
+
+          # Disabled long enough ago that it should be removed.
+          cat > "${tap_dir}/Formula/removable.rb" <<'RUBY'
+          class Removable < Formula
+            desc "Disabled long enough ago to be removed"
+            homepage "https://brew.sh"
+            url "https://brew.sh/removable-1.0.tar.gz"
+            version "1.0"
+
+            disable! date: "2000-01-01", because: :unmaintained
+          end
+          RUBY
+
+          # Disabled recently enough that it should be kept.
+          recent_date="$(date -d '1 month ago' +%F)"
+          cat > "${tap_dir}/Formula/kept.rb" <<RUBY
+          class Kept < Formula
+            desc "Disabled too recently to be removed"
+            homepage "https://brew.sh"
+            url "https://brew.sh/kept-1.0.tar.gz"
+            version "1.0"
+
+            disable! date: "${recent_date}", because: :unmaintained
+          end
+          RUBY
+
+          # Not disabled at all, so it should be kept.
+          cat > "${tap_dir}/Formula/active.rb" <<'RUBY'
+          class Active < Formula
+            desc "Not disabled"
+            homepage "https://brew.sh"
+            url "https://brew.sh/active-1.0.tar.gz"
+            version "1.0"
+          end
+          RUBY
+
+          git -C "${tap_dir}" init --quiet
+          git -C "${tap_dir}" add --all
+          git -C "${tap_dir}" commit --quiet --message "Add fixture formulae"
+
+          echo "tap-dir=${tap_dir}" >> "${GITHUB_OUTPUT}"
+
+      - name: Remove disabled packages
+        id: remove
+        uses: ./remove-disabled-packages/
+
+      - name: Verify only the long-disabled formula was removed
+        env:
+          TAP_DIR: ${{ steps.fixture.outputs.tap-dir }}
+          PACKAGES_REMOVED: ${{ steps.remove.outputs.packages-removed }}
+        run: |
+          [[ "${PACKAGES_REMOVED}" = "true" ]]
+
+          [[ ! -f "${TAP_DIR}/Formula/removable.rb" ]]
+          [[ -f "${TAP_DIR}/Formula/kept.rb" ]]
+          [[ -f "${TAP_DIR}/Formula/active.rb" ]]
+
+          git_log="$(git -C "${TAP_DIR}" log --format='%s')"
+          grep --quiet "removable: remove formula" <<<"${git_log}"

--- a/bump-packages/action.test.mts
+++ b/bump-packages/action.test.mts
@@ -1,0 +1,88 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import yaml from "js-yaml";
+
+type Step = {
+  name?: string;
+  run?: string;
+};
+
+type Action = {
+  runs: {
+    steps: Step[];
+  };
+};
+
+const action = yaml.load(
+  fs.readFileSync(new URL("action.yml", import.meta.url), "utf8"),
+) as Action;
+
+function actionStep(name: string): Step {
+  const step = action.runs.steps.find((candidate) => candidate.name === name);
+  assert.ok(step, `Expected ${name} step to exist.`);
+  return step;
+}
+
+function brewBumpArgs(stepName: string, env: Record<string, string>): string[] {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "bump-packages-"));
+
+  try {
+    const bin = path.join(directory, "bin");
+    const log = path.join(directory, "brew.log");
+    fs.mkdirSync(bin);
+    fs.writeFileSync(path.join(bin, "brew"), [
+      "#!/bin/sh",
+      'printf "%s\\n" "$@" >> "$BREW_LOG"',
+    ].join("\n"));
+    fs.chmodSync(path.join(bin, "brew"), 0o755);
+
+    execFileSync("/bin/bash", ["-e", "-o", "pipefail", "-c", actionStep(stepName).run!], {
+      env: {
+        ...process.env,
+        ...env,
+        BREW_LOG: log,
+        PATH: `${bin}:${process.env.PATH}`,
+      },
+      stdio: "ignore",
+    });
+
+    return fs.readFileSync(log, "utf8").trimEnd().split("\n");
+  } finally {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+describe("bump-packages action", () => {
+  it("bumps formulae with --no-fork when not using a fork", () => {
+    assert.deepEqual(brewBumpArgs("Bump formulae", { INPUT_FORMULAE: "foo bar", INPUT_FORK: "false" }), [
+      "bump",
+      "--no-fork",
+      "--open-pr",
+      "--formulae",
+      "foo",
+      "bar",
+    ]);
+  });
+
+  it("bumps formulae without --no-fork when using a fork", () => {
+    assert.deepEqual(brewBumpArgs("Bump formulae", { INPUT_FORMULAE: "foo", INPUT_FORK: "true" }), [
+      "bump",
+      "--open-pr",
+      "--formulae",
+      "foo",
+    ]);
+  });
+
+  it("bumps casks with --no-fork when not using a fork", () => {
+    assert.deepEqual(brewBumpArgs("Bump casks", { INPUT_CASKS: "baz qux", INPUT_FORK: "false" }), [
+      "bump",
+      "--no-fork",
+      "--open-pr",
+      "--casks",
+      "baz",
+      "qux",
+    ]);
+  });
+});

--- a/failures-summary-and-bottle-result/action.test.mts
+++ b/failures-summary-and-bottle-result/action.test.mts
@@ -1,0 +1,91 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import yaml from "js-yaml";
+
+type Step = {
+  name?: string;
+  run?: string;
+};
+
+type Action = {
+  runs: {
+    steps: Step[];
+  };
+};
+
+const action = yaml.load(
+  fs.readFileSync(new URL("action.yml", import.meta.url), "utf8"),
+) as Action;
+
+const summaryStep = action.runs.steps.find((step) => step.run?.includes("GITHUB_STEP_SUMMARY"))!;
+
+function runSummary(resultContents: string | null, collapse = "false") {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "failures-summary-"));
+
+  try {
+    const summary = path.join(directory, "summary.md");
+    const resultPath = "bottles/steps_output.txt";
+    fs.writeFileSync(summary, "");
+    if (resultContents !== null) {
+      fs.mkdirSync(path.join(directory, "bottles"));
+      fs.writeFileSync(path.join(directory, resultPath), resultContents);
+    }
+
+    execFileSync("/bin/bash", ["-e", "-u", "-o", "pipefail", "-c", summaryStep.run!], {
+      env: {
+        ...process.env,
+        GITHUB_STEP_SUMMARY: summary,
+        WORKDIR: directory,
+        RESULT_PATH: resultPath,
+        STEP_NAME: "`brew test-bot` output",
+        COLLAPSE: collapse,
+      },
+      stdio: "ignore",
+    });
+
+    return {
+      summary: fs.readFileSync(summary, "utf8"),
+      resultExists: resultContents !== null && fs.existsSync(path.join(directory, resultPath)),
+    };
+  } finally {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+describe("failures-summary-and-bottle-result action", () => {
+  it("appends the heading and fenced result, then removes the result file", () => {
+    const { summary, resultExists } = runSummary("install succeeded\n");
+
+    assert.match(summary, /### `brew test-bot` output/);
+    assert.match(summary, /```\ninstall succeeded\n\n```/);
+    assert.equal(resultExists, false);
+  });
+
+  it("strips ANSI colour codes from the result", () => {
+    const { summary } = runSummary("\x1b[31mError:\x1b[0m broken\n");
+
+    assert.match(summary, /^Error: broken$/m);
+    assert.doesNotMatch(summary, /\x1b\[/);
+  });
+
+  it("wraps the output in a collapsed details block", () => {
+    const { summary } = runSummary("some output\n", "true");
+
+    assert.match(summary, /<details><summary>Details<\/summary>/);
+    assert.match(summary, /<\/p>\n<\/details>/);
+  });
+
+  it("does nothing when the result file is missing", () => {
+    const { summary } = runSummary(null);
+
+    assert.equal(summary, "");
+  });
+
+  it("does nothing when the result file is empty", () => {
+    const { summary } = runSummary("");
+
+    assert.equal(summary, "");
+  });
+});

--- a/post-build/count-bottles.test.mts
+++ b/post-build/count-bottles.test.mts
@@ -1,0 +1,58 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const script = new URL("count-bottles.sh", import.meta.url).pathname;
+
+function countBottles(files: string[]) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "count-bottles-"));
+
+  try {
+    const githubOutput = path.join(directory, "github-output");
+    fs.writeFileSync(githubOutput, "");
+    for (const file of files) {
+      fs.mkdirSync(path.join(directory, path.dirname(file)), { recursive: true });
+      fs.writeFileSync(path.join(directory, file), "");
+    }
+
+    execFileSync(script, ["false"], {
+      cwd: directory,
+      env: { ...process.env, GITHUB_OUTPUT: githubOutput },
+      stdio: "ignore",
+    });
+
+    return Object.fromEntries(
+      fs.readFileSync(githubOutput, "utf8").trimEnd().split("\n").map((line) => line.split("=", 2)),
+    );
+  } finally {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+describe("count-bottles.sh", () => {
+  it("reports zero for an empty directory", () => {
+    assert.deepEqual(countBottles([]), {
+      count: "0",
+      failures: "0",
+      skipped: "0",
+      dependents: "0",
+    });
+  });
+
+  it("counts bottles, failures, skipped lists and tested dependents", () => {
+    assert.deepEqual(countBottles([
+      "foo.json",
+      "bar.json",
+      "failed/baz.json",
+      "skipped_or_failed_formulae-macOS.txt",
+      "tested-dependents-macOS.txt",
+      "tested-dependents-Linux.txt",
+    ]), {
+      count: "2",
+      failures: "1",
+      skipped: "1",
+      dependents: "2",
+    });
+  });
+});

--- a/pre-build/action.test.mts
+++ b/pre-build/action.test.mts
@@ -1,0 +1,94 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import yaml from "js-yaml";
+
+type Step = {
+  name?: string;
+  run?: string;
+};
+
+type Action = {
+  runs: {
+    steps: Step[];
+  };
+};
+
+const action = yaml.load(
+  fs.readFileSync(new URL("action.yml", import.meta.url), "utf8"),
+) as Action;
+
+function actionStep(name: string): Step {
+  const step = action.runs.steps.find((candidate) => candidate.name === name);
+  assert.ok(step, `Expected ${name} step to exist.`);
+  return step;
+}
+
+function runStep(name: string, env: Record<string, string>, stubs: Record<string, string> = {}) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "pre-build-"));
+
+  try {
+    const bin = path.join(directory, "bin");
+    fs.mkdirSync(bin);
+    for (const [command, output] of Object.entries(stubs)) {
+      fs.writeFileSync(path.join(bin, command), `#!/bin/sh\necho "${output}"\n`);
+      fs.chmodSync(path.join(bin, command), 0o755);
+    }
+
+    const githubOutput = path.join(directory, "github-output");
+    fs.writeFileSync(githubOutput, "");
+
+    execFileSync("/bin/bash", ["-e", "-u", "-o", "pipefail", "-c", actionStep(name).run!], {
+      cwd: directory,
+      env: {
+        ...process.env,
+        ...env,
+        GITHUB_OUTPUT: githubOutput,
+        PATH: `${bin}:${process.env.PATH}`,
+      },
+      stdio: "ignore",
+    });
+
+    return Object.fromEntries(
+      fs.readFileSync(githubOutput, "utf8").trimEnd().split("\n").filter(Boolean).map((line) => line.split("=", 2)),
+    );
+  } finally {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+describe("pre-build action", () => {
+  it("keys the RubyGems cache by OS on Linux", () => {
+    assert.deepEqual(runStep("Set up RubyGems cache", { RUNNER_OS: "Linux" }), {
+      cache_key_prefix: "Linux",
+      macos_version: "",
+      arch: "",
+    });
+  });
+
+  it("keys the RubyGems cache by macOS version and architecture", () => {
+    assert.deepEqual(
+      runStep("Set up RubyGems cache", { RUNNER_OS: "macOS" }, { "sw_vers": "14.5.1", "uname": "arm64" }),
+      {
+        cache_key_prefix: "14-arm64",
+        macos_version: "14",
+        arch: "arm64",
+      },
+    );
+  });
+
+  it("computes the Linux bottle specifier", () => {
+    assert.deepEqual(
+      runStep("Set up bottles directory", { RUNNER_OS: "Linux", BOTTLES_DIR: "bottles", MACOS_VERSION: "", ARCH: "" }),
+      { bottle_specifier: "{ubuntu,linux}" },
+    );
+  });
+
+  it("computes the macOS bottle specifier", () => {
+    assert.deepEqual(
+      runStep("Set up bottles directory", { RUNNER_OS: "macOS", BOTTLES_DIR: "bottles", MACOS_VERSION: "14", ARCH: "arm64" }),
+      { bottle_specifier: "{macos-14,14-arm64}" },
+    );
+  });
+});

--- a/wait-for-idle-runner/main.mts
+++ b/wait-for-idle-runner/main.mts
@@ -48,4 +48,4 @@ async function main() {
   }
 }
 
-main()
+await main()

--- a/wait-for-idle-runner/main.test.mts
+++ b/wait-for-idle-runner/main.test.mts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+describe("wait-for-idle-runner", () => {
+  const token = "fake-token";
+  const runnerName = "linux-self-hosted-1";
+
+  let directory: string;
+  let githubOutput: string;
+
+  beforeEach(async () => {
+    directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), "wait-for-idle-runner-"));
+    githubOutput = path.join(directory, "github-output");
+    await fs.promises.writeFile(githubOutput, "");
+    process.env.GITHUB_OUTPUT = githubOutput;
+
+    mockInput("github_token", token);
+    mockInput("runner_name", runnerName);
+    mockInput("repository_name", GITHUB_REPOSITORY);
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(directory, { recursive: true });
+  });
+
+  function outputs() {
+    const lines = fs.readFileSync(githubOutput, "utf8").split("\n");
+    const result: Record<string, string> = {};
+    for (let i = 0; i < lines.length; i++) {
+      const match = lines[i].match(/^(.+)<<(\S+)$/);
+      if (!match) continue;
+      const [, key, delimiter] = match;
+      const value = [];
+      while (++i < lines.length && lines[i] !== delimiter) value.push(lines[i]);
+      assert.ok(i < lines.length, `Unterminated heredoc for ${key} in GITHUB_OUTPUT`);
+      result[key] = value.join("\n");
+    }
+    return result;
+  }
+
+  function interceptRunners(runners: { name: string; busy: boolean }[]) {
+    githubMockPool().intercept({
+      method: "GET",
+      path: `/repos/${GITHUB_REPOSITORY}/actions/runners`,
+      headers: {
+        Authorization: `token ${token}`,
+      },
+    }).defaultReplyHeaders({
+      "Content-Type": "application/json",
+    }).reply(200, { total_count: runners.length, runners });
+  }
+
+  it("reports an idle runner as found and idle", async () => {
+    interceptRunners([{ name: runnerName, busy: false }]);
+
+    await loadMain();
+
+    assert.deepEqual(outputs(), { "runner-found": "true", "runner-idle": "true" });
+  });
+
+  it("reports a missing runner as not found", async () => {
+    interceptRunners([{ name: "some-other-runner", busy: false }]);
+
+    await loadMain();
+
+    assert.deepEqual(outputs(), { "runner-found": "false" });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/Homebrew/actions/issues/549

- cover `wait-for-idle-runner`, `failures-summary-and-bottle-result`, `post-build`, `bump-packages` and `pre-build` in the Node suite so changes are no longer merged blind (Homebrew/actions#549)
- reuse the `setup-ruby` pattern of extracting a composite step's shell and running it with a stubbed `PATH` to test shell-only logic
- await `main()` in `wait-for-idle-runner` so failures surface and the test can wait for completion, matching `find-related-workflow-run-id`
- add a secret-free `remove-disabled-packages` workflow that exercises the Ruby against a throwaway fixture tap, since it needs `brew ruby`