### PR TITLE
bump-packages: support tap-qualified package names

### DIFF
--- a/bump-packages/README.md
+++ b/bump-packages/README.md
@@ -31,7 +31,5 @@ If there are no outdated packages, the Action will just exit.
       ...
     # Do not use a fork for opening PR's
     fork: false
-    # Fully-qualified names, e.g. user/tap/formula, are detected automatically.
-    # Set this to force --full-name for short names too.
-    full-name: true
+    # Tap-qualified names, e.g. user/tap/formula, are detected automatically.
 ```

--- a/bump-packages/README.md
+++ b/bump-packages/README.md
@@ -31,6 +31,7 @@ If there are no outdated packages, the Action will just exit.
       ...
     # Do not use a fork for opening PR's
     fork: false
-    # Package names are fully-qualified, e.g. user/tap/formula
+    # Fully-qualified names, e.g. user/tap/formula, are detected automatically.
+    # Set this to force --full-name for short names too.
     full-name: true
 ```

--- a/bump-packages/README.md
+++ b/bump-packages/README.md
@@ -31,4 +31,6 @@ If there are no outdated packages, the Action will just exit.
       ...
     # Do not use a fork for opening PR's
     fork: false
+    # Package names are fully-qualified, e.g. user/tap/formula
+    full-name: true
 ```

--- a/bump-packages/action.test.mts
+++ b/bump-packages/action.test.mts
@@ -75,6 +75,21 @@ describe("bump-packages action", () => {
     ]);
   });
 
+  it("bumps fully-qualified formulae with --full-name", () => {
+    assert.deepEqual(brewBumpArgs("Bump formulae", {
+      INPUT_FORMULAE: "user/tap/foo",
+      INPUT_FORK: "false",
+      INPUT_FULL_NAME: "true",
+    }), [
+      "bump",
+      "--no-fork",
+      "--full-name",
+      "--open-pr",
+      "--formulae",
+      "user/tap/foo",
+    ]);
+  });
+
   it("bumps casks with --no-fork when not using a fork", () => {
     assert.deepEqual(brewBumpArgs("Bump casks", { INPUT_CASKS: "baz qux", INPUT_FORK: "false" }), [
       "bump",
@@ -83,6 +98,21 @@ describe("bump-packages action", () => {
       "--casks",
       "baz",
       "qux",
+    ]);
+  });
+
+  it("bumps fully-qualified casks with --full-name", () => {
+    assert.deepEqual(brewBumpArgs("Bump casks", {
+      INPUT_CASKS: "user/tap/baz",
+      INPUT_FORK: "false",
+      INPUT_FULL_NAME: "true",
+    }), [
+      "bump",
+      "--no-fork",
+      "--full-name",
+      "--open-pr",
+      "--casks",
+      "user/tap/baz",
     ]);
   });
 });

--- a/bump-packages/action.test.mts
+++ b/bump-packages/action.test.mts
@@ -89,21 +89,6 @@ describe("bump-packages action", () => {
     ]);
   });
 
-  it("forces --full-name for short formula names", () => {
-    assert.deepEqual(brewBumpArgs("Bump formulae", {
-      INPUT_FORMULAE: "foo",
-      INPUT_FORK: "false",
-      INPUT_FULL_NAME: "true",
-    }), [
-      "bump",
-      "--no-fork",
-      "--full-name",
-      "--open-pr",
-      "--formulae",
-      "foo",
-    ]);
-  });
-
   it("bumps casks with --no-fork when not using a fork", () => {
     assert.deepEqual(brewBumpArgs("Bump casks", { INPUT_CASKS: "baz qux", INPUT_FORK: "false" }), [
       "bump",
@@ -129,18 +114,4 @@ describe("bump-packages action", () => {
     ]);
   });
 
-  it("forces --full-name for short cask names", () => {
-    assert.deepEqual(brewBumpArgs("Bump casks", {
-      INPUT_CASKS: "baz",
-      INPUT_FORK: "false",
-      INPUT_FULL_NAME: "true",
-    }), [
-      "bump",
-      "--no-fork",
-      "--full-name",
-      "--open-pr",
-      "--casks",
-      "baz",
-    ]);
-  });
 });

--- a/bump-packages/action.test.mts
+++ b/bump-packages/action.test.mts
@@ -75,9 +75,23 @@ describe("bump-packages action", () => {
     ]);
   });
 
-  it("bumps fully-qualified formulae with --full-name", () => {
+  it("bumps fully-qualified formulae with --full-name automatically", () => {
     assert.deepEqual(brewBumpArgs("Bump formulae", {
       INPUT_FORMULAE: "user/tap/foo",
+      INPUT_FORK: "false",
+    }), [
+      "bump",
+      "--no-fork",
+      "--full-name",
+      "--open-pr",
+      "--formulae",
+      "user/tap/foo",
+    ]);
+  });
+
+  it("forces --full-name for short formula names", () => {
+    assert.deepEqual(brewBumpArgs("Bump formulae", {
+      INPUT_FORMULAE: "foo",
       INPUT_FORK: "false",
       INPUT_FULL_NAME: "true",
     }), [
@@ -86,7 +100,7 @@ describe("bump-packages action", () => {
       "--full-name",
       "--open-pr",
       "--formulae",
-      "user/tap/foo",
+      "foo",
     ]);
   });
 
@@ -101,9 +115,23 @@ describe("bump-packages action", () => {
     ]);
   });
 
-  it("bumps fully-qualified casks with --full-name", () => {
+  it("bumps fully-qualified casks with --full-name automatically", () => {
     assert.deepEqual(brewBumpArgs("Bump casks", {
       INPUT_CASKS: "user/tap/baz",
+      INPUT_FORK: "false",
+    }), [
+      "bump",
+      "--no-fork",
+      "--full-name",
+      "--open-pr",
+      "--casks",
+      "user/tap/baz",
+    ]);
+  });
+
+  it("forces --full-name for short cask names", () => {
+    assert.deepEqual(brewBumpArgs("Bump casks", {
+      INPUT_CASKS: "baz",
       INPUT_FORK: "false",
       INPUT_FULL_NAME: "true",
     }), [
@@ -112,7 +140,7 @@ describe("bump-packages action", () => {
       "--full-name",
       "--open-pr",
       "--casks",
-      "user/tap/baz",
+      "baz",
     ]);
   });
 });

--- a/bump-packages/action.yml
+++ b/bump-packages/action.yml
@@ -43,7 +43,7 @@ runs:
         fi
         args+=(--open-pr)
         IFS=" " read -r -a formulae <<<"${INPUT_FORMULAE}"
-        brew "${args[@]}" --formulae "${formulae[@]}"
+        brew bump "${args[@]}" --formulae "${formulae[@]}"
       shell: bash
       if: inputs.formulae != ''
       env:

--- a/bump-packages/action.yml
+++ b/bump-packages/action.yml
@@ -20,10 +20,6 @@ inputs:
     description: Use a fork when opening a PR
     required: false
     default: ${{ github.repository_owner != 'Homebrew' }}
-  full-name:
-    description: Force fully-qualified package names to brew bump
-    required: false
-    default: 'false'
 runs:
   using: composite
   steps:
@@ -39,7 +35,7 @@ runs:
           args+=(--no-fork)
         fi
         IFS=" " read -r -a formulae <<<"${INPUT_FORMULAE}"
-        if [[ "$INPUT_FULL_NAME" == "true" || "${formulae[*]}" == */* ]]; then
+        if [[ "${formulae[*]}" == */* ]]; then
           args+=(--full-name)
         fi
         args+=(--open-pr)
@@ -49,7 +45,6 @@ runs:
       env:
         INPUT_FORMULAE: ${{ inputs.formulae }}
         INPUT_FORK: ${{ inputs.fork }}
-        INPUT_FULL_NAME: ${{ inputs.full-name }}
         HOMEBREW_DEVELOPER: "1"
         HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}
     - name: Bump casks
@@ -59,7 +54,7 @@ runs:
           args+=(--no-fork)
         fi
         IFS=" " read -r -a casks <<<"${INPUT_CASKS}"
-        if [[ "$INPUT_FULL_NAME" == "true" || "${casks[*]}" == */* ]]; then
+        if [[ "${casks[*]}" == */* ]]; then
           args+=(--full-name)
         fi
         args+=(--open-pr)
@@ -69,6 +64,5 @@ runs:
       env:
         INPUT_CASKS: ${{ inputs.casks }}
         INPUT_FORK: ${{ inputs.fork }}
-        INPUT_FULL_NAME: ${{ inputs.full-name }}
         HOMEBREW_DEVELOPER: "1"
         HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}

--- a/bump-packages/action.yml
+++ b/bump-packages/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: Use a fork when opening a PR
     required: false
     default: ${{ github.repository_owner != 'Homebrew' }}
+  full-name:
+    description: Pass fully-qualified package names to brew bump
+    required: false
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -30,33 +34,41 @@ runs:
 
     - name: Bump formulae
       run: |
-        if [[ "$INPUT_FORK" == "true" ]]; then
-          NO_FORK=""
-        else
-          NO_FORK="--no-fork"
+        args=(bump)
+        if [[ "$INPUT_FORK" != "true" ]]; then
+          args+=(--no-fork)
         fi
+        if [[ "$INPUT_FULL_NAME" == "true" ]]; then
+          args+=(--full-name)
+        fi
+        args+=(--open-pr)
         IFS=" " read -r -a formulae <<<"${INPUT_FORMULAE}"
-        brew bump $NO_FORK --open-pr --formulae "${formulae[@]}"
+        brew "${args[@]}" --formulae "${formulae[@]}"
       shell: bash
       if: inputs.formulae != ''
       env:
         INPUT_FORMULAE: ${{ inputs.formulae }}
         INPUT_FORK: ${{ inputs.fork }}
+        INPUT_FULL_NAME: ${{ inputs.full-name }}
         HOMEBREW_DEVELOPER: "1"
         HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}
     - name: Bump casks
       run: |
-        if [[ "$INPUT_FORK" == "true" ]]; then
-          NO_FORK=""
-        else
-          NO_FORK="--no-fork"
+        args=(bump)
+        if [[ "$INPUT_FORK" != "true" ]]; then
+          args+=(--no-fork)
         fi
+        if [[ "$INPUT_FULL_NAME" == "true" ]]; then
+          args+=(--full-name)
+        fi
+        args+=(--open-pr)
         IFS=" " read -r -a casks <<<"${INPUT_CASKS}"
-        brew bump $NO_FORK --open-pr --casks "${casks[@]}"
+        brew "${args[@]}" --casks "${casks[@]}"
       shell: bash
       if: inputs.casks != ''
       env:
         INPUT_CASKS: ${{ inputs.casks }}
         INPUT_FORK: ${{ inputs.fork }}
+        INPUT_FULL_NAME: ${{ inputs.full-name }}
         HOMEBREW_DEVELOPER: "1"
         HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}

--- a/bump-packages/action.yml
+++ b/bump-packages/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: ${{ github.repository_owner != 'Homebrew' }}
   full-name:
-    description: Pass fully-qualified package names to brew bump
+    description: Force fully-qualified package names to brew bump
     required: false
     default: 'false'
 runs:
@@ -34,15 +34,15 @@ runs:
 
     - name: Bump formulae
       run: |
-        args=(bump)
+        args=()
         if [[ "$INPUT_FORK" != "true" ]]; then
           args+=(--no-fork)
         fi
-        if [[ "$INPUT_FULL_NAME" == "true" ]]; then
+        IFS=" " read -r -a formulae <<<"${INPUT_FORMULAE}"
+        if [[ "$INPUT_FULL_NAME" == "true" || "${formulae[*]}" == */* ]]; then
           args+=(--full-name)
         fi
         args+=(--open-pr)
-        IFS=" " read -r -a formulae <<<"${INPUT_FORMULAE}"
         brew bump "${args[@]}" --formulae "${formulae[@]}"
       shell: bash
       if: inputs.formulae != ''
@@ -54,16 +54,16 @@ runs:
         HOMEBREW_GITHUB_API_TOKEN: ${{ inputs.token }}
     - name: Bump casks
       run: |
-        args=(bump)
+        args=()
         if [[ "$INPUT_FORK" != "true" ]]; then
           args+=(--no-fork)
         fi
-        if [[ "$INPUT_FULL_NAME" == "true" ]]; then
+        IFS=" " read -r -a casks <<<"${INPUT_CASKS}"
+        if [[ "$INPUT_FULL_NAME" == "true" || "${casks[*]}" == */* ]]; then
           args+=(--full-name)
         fi
         args+=(--open-pr)
-        IFS=" " read -r -a casks <<<"${INPUT_CASKS}"
-        brew "${args[@]}" --casks "${casks[@]}"
+        brew bump "${args[@]}" --casks "${casks[@]}"
       shell: bash
       if: inputs.casks != ''
       env:


### PR DESCRIPTION
Summary:
- Auto-enable `--full-name` for formula and cask names containing `/`.
- Remove the redundant `full-name` input.
- Update docs and tests for both command paths.
