### PR TITLE
release: add repository-wide CalVer versioning

### DIFF
--- a/.github/scripts/prepare-release.sh
+++ b/.github/scripts/prepare-release.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly CALVER_PATTERN='^[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[1-9][0-9]*$'
+
+event_name="${GITHUB_EVENT_NAME:-workflow_dispatch}"
+minimum_age_seconds="${RELEASE_MINIMUM_AGE_SECONDS:-86400}"
+now="${RELEASE_NOW:-$(date -u +%s)}"
+release_date="${RELEASE_DATE:-$(date -u +%Y.%m.%d)}"
+
+if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+  echo "GITHUB_OUTPUT must be set." >&2
+  exit 1
+fi
+
+if [[ ! "${minimum_age_seconds}" =~ ^[0-9]+$ ]]; then
+  echo "RELEASE_MINIMUM_AGE_SECONDS must be a non-negative integer." >&2
+  exit 1
+fi
+
+if [[ ! "${now}" =~ ^[0-9]+$ ]]; then
+  echo "RELEASE_NOW must be a non-negative integer." >&2
+  exit 1
+fi
+
+if [[ ! "${release_date}" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}$ ]]; then
+  echo "RELEASE_DATE must use YYYY.MM.DD." >&2
+  exit 1
+fi
+
+case "${event_name}" in
+  schedule | workflow_dispatch) ;;
+  *)
+    echo "Unsupported release event: ${event_name}" >&2
+    exit 1
+    ;;
+esac
+
+write_output() {
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT}"
+}
+
+candidate_sha="$(git rev-parse HEAD)"
+candidate_timestamp="$(git show -s --format=%ct "${candidate_sha}")"
+# Clamp to zero so a future-dated commit (clock skew) reads as freshest rather
+# than reporting a negative age and slipping past the bake gate.
+candidate_age_seconds="$(( now > candidate_timestamp ? now - candidate_timestamp : 0 ))"
+latest_tag=""
+
+while IFS= read -r tag; do
+  if [[ "${tag}" =~ ${CALVER_PATTERN} ]]; then
+    latest_tag="${tag}"
+    break
+  fi
+done < <(git tag --merged "${candidate_sha}" --sort=-version:refname)
+
+write_output candidate_sha "${candidate_sha}"
+write_output candidate_age_seconds "${candidate_age_seconds}"
+write_output latest_tag "${latest_tag}"
+
+if [[ -n "${latest_tag}" ]] &&
+   [[ "$(git rev-list --count "${latest_tag}..${candidate_sha}")" -eq 0 ]]; then
+  reason="No commits since ${latest_tag}."
+  write_output release false
+  write_output reason "${reason}"
+  echo "${reason} Skipping release."
+  exit 0
+fi
+
+if [[ "${event_name}" == "schedule" ]] &&
+   (( candidate_age_seconds < minimum_age_seconds )); then
+  reason="Candidate commit is ${candidate_age_seconds} seconds old; scheduled releases require ${minimum_age_seconds} seconds."
+  write_output release false
+  write_output reason "${reason}"
+  echo "${reason} Skipping release."
+  exit 0
+fi
+
+escaped_release_date="${release_date//./\.}"
+release_tag_pattern="^${escaped_release_date}\.([1-9][0-9]*)$"
+highest_sequence=0
+
+while IFS= read -r tag; do
+  if [[ "${tag}" =~ ${release_tag_pattern} ]]; then
+    sequence="$((10#${BASH_REMATCH[1]}))"
+    if (( sequence > highest_sequence )); then
+      highest_sequence="${sequence}"
+    fi
+  fi
+done < <(git tag --list "${release_date}.*")
+
+version="${release_date}.$((highest_sequence + 1))"
+reason="Release ${candidate_sha} as ${version}."
+
+write_output release true
+write_output version "${version}"
+write_output reason "${reason}"
+echo "${reason}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  schedule:
+    # Every Monday at 12:00 UTC.
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release
+    if: github.repository_owner == 'Homebrew'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for creating the release and tag
+    steps:
+      - name: Check out main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+          ref: main
+
+      - name: Prepare release
+        id: release
+        env:
+          RELEASE_MINIMUM_AGE_SECONDS: 86400
+        run: .github/scripts/prepare-release.sh
+
+      - name: Create release
+        if: steps.release.outputs.release == 'true'
+        env:
+          CANDIDATE_SHA: ${{ steps.release.outputs.candidate_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          if gh api "repos/${REPOSITORY}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag ${VERSION} already exists; release tags are immutable."
+            exit 1
+          fi
+
+          gh release create "${VERSION}" \
+            --repo "${REPOSITORY}" \
+            --target "${CANDIDATE_SHA}" \
+            --title "${VERSION}" \
+            --generate-notes \
+            --fail-on-no-commits

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Prepare release
         id: release
         env:
+          # Scheduled releases require the candidate commit to be at least 24 hours old.
+          # Manual dispatches bypass this bake-time requirement.
           RELEASE_MINIMUM_AGE_SECONDS: 86400
         run: .github/scripts/prepare-release.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@ Navigate to subdirectories for more information about particular Actions.
 
 Every directory (except `node_modules`) is a separate Action.
 
+## Releases
+
+All Actions in this repository are released together using bare CalVer tags in
+the form `YYYY.MM.DD.N`, where `N` starts at 1 each UTC day. Release tags point
+directly to commits on `main` and are never moved. Each tag has a published
+GitHub Release with generated release notes. CalVer identifies when a snapshot
+was cut; it does not imply semantic compatibility, a support window, or
+multiple maintained release tracks.
+
+Consumers can use an exact CalVer tag for readability. Environments that
+require immutable third-party action pins should use the tag's full commit SHA
+and retain the CalVer tag in a comment.
+
+A scheduled workflow runs every Monday at 12:00 UTC. It skips the release when
+there are no commits since the latest CalVer tag or when the latest commit has
+had less than 24 hours to bake. Maintainers can dispatch the workflow manually
+to release an urgent fix without waiting for the bake period. A recent commit
+defers the entire scheduled release, including older changes that have already
+had time to bake.
+
 ## Development
 
 In Actions' subdirectories, there are no separate `node_modules` directories or `package-lock.json` files.

--- a/bump-formulae/action.yml
+++ b/bump-formulae/action.yml
@@ -22,7 +22,7 @@ runs:
     - run: echo "::warning::Homebrew/actions/bump-formulae is deprecated. Please use Homebrew/actions/bump-packages instead."
       shell: sh
 
-    - uses: Homebrew/actions/bump-packages@main
+    - uses: Homebrew/actions/bump-packages@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
       with:
         token: ${{ inputs.token }}
         formulae: ${{ inputs.formulae }}

--- a/bump-formulae/action.yml
+++ b/bump-formulae/action.yml
@@ -22,7 +22,7 @@ runs:
     - run: echo "::warning::Homebrew/actions/bump-formulae is deprecated. Please use Homebrew/actions/bump-packages instead."
       shell: sh
 
-    - uses: Homebrew/actions/bump-packages@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
+    - uses: Homebrew/actions/bump-packages@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
       with:
         token: ${{ inputs.token }}
         formulae: ${{ inputs.formulae }}

--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Failures summary for brew test-bot
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@main
+      uses: Homebrew/actions/failures-summary-and-bottle-result@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: steps_output.txt
@@ -36,7 +36,7 @@ runs:
 
     - name: Output brew linkage result
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@main
+      uses: Homebrew/actions/failures-summary-and-bottle-result@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: linkage_output.txt
@@ -45,7 +45,7 @@ runs:
 
     - name: Output brew bottle result
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@main
+      uses: Homebrew/actions/failures-summary-and-bottle-result@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: bottle_output.txt

--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Failures summary for brew test-bot
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
+      uses: Homebrew/actions/failures-summary-and-bottle-result@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: steps_output.txt
@@ -36,7 +36,7 @@ runs:
 
     - name: Output brew linkage result
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
+      uses: Homebrew/actions/failures-summary-and-bottle-result@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: linkage_output.txt
@@ -45,7 +45,7 @@ runs:
 
     - name: Output brew bottle result
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
+      uses: Homebrew/actions/failures-summary-and-bottle-result@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: bottle_output.txt

--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Set up Homebrew
       id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@main
+      uses: Homebrew/actions/setup-homebrew@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
       with:
         core: true
         cask: true

--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Set up Homebrew
       id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
+      uses: Homebrew/actions/setup-homebrew@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
       with:
         core: true
         cask: true

--- a/release.test.mts
+++ b/release.test.mts
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import * as yaml from "js-yaml";
+
+type ActionStep = {
+  uses?: string;
+};
+
+type ActionMetadata = {
+  runs?: {
+    steps?: ActionStep[];
+  };
+};
+
+const REPOSITORY_ROOT = fileURLToPath(new URL(".", import.meta.url));
+const PREPARE_RELEASE = fileURLToPath(
+  new URL("./.github/scripts/prepare-release.sh", import.meta.url),
+);
+
+function git(repository: string, ...arguments_: string[]): string {
+  return execFileSync("git", ["-C", repository, ...arguments_], {
+    encoding: "utf8",
+  }).trim();
+}
+
+function repository(): string {
+  const path = mkdtempSync(join(tmpdir(), "homebrew-actions-release-"));
+  git(path, "init", "--initial-branch=main");
+  git(path, "config", "user.email", "test@example.com");
+  git(path, "config", "user.name", "Release Test");
+  git(path, "config", "commit.gpgsign", "false");
+  git(path, "config", "tag.gpgsign", "false");
+  return path;
+}
+
+function commit(repository: string, message: string, date: string): string {
+  appendFileSync(join(repository, "state.txt"), `${message}\n`);
+  git(repository, "add", "state.txt");
+  execFileSync("git", ["-C", repository, "commit", "-m", message], {
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: date,
+      GIT_COMMITTER_DATE: date,
+    },
+  });
+  return git(repository, "rev-parse", "HEAD");
+}
+
+function tag(repository: string, name: string): void {
+  git(repository, "tag", "--annotate", name, "--message", name);
+}
+
+function prepare(
+  repository: string,
+  eventName: "schedule" | "workflow_dispatch",
+  now: string,
+  releaseDate = "2026.07.06",
+): Record<string, string> {
+  const output = join(repository, "github-output");
+  writeFileSync(output, "");
+
+  const result = spawnSync("bash", [PREPARE_RELEASE], {
+    cwd: repository,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GITHUB_EVENT_NAME: eventName,
+      GITHUB_OUTPUT: output,
+      RELEASE_DATE: releaseDate,
+      RELEASE_MINIMUM_AGE_SECONDS: "86400",
+      RELEASE_NOW: now,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+
+  return Object.fromEntries(
+    readFileSync(output, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return [line.slice(0, separator), line.slice(separator + 1)];
+      }),
+  );
+}
+
+test("prepares the first scheduled release from an old commit", (t) => {
+  const path = repository();
+  t.after(() => rmSync(path, { force: true, recursive: true }));
+
+  const candidate = commit(path, "initial", "2026-07-05T12:00:00Z");
+  const output = prepare(path, "schedule", "1783339200");
+
+  assert.equal(output.release, "true");
+  assert.equal(output.version, "2026.07.06.1");
+  assert.equal(output.candidate_sha, candidate);
+});
+
+test("increments the sequence for the UTC release date", (t) => {
+  const path = repository();
+  t.after(() => rmSync(path, { force: true, recursive: true }));
+
+  commit(path, "released", "2026-07-04T12:00:00Z");
+  tag(path, "2026.07.06.1");
+  tag(path, "v2026.07.06.9");
+  commit(path, "next", "2026-07-05T12:00:00Z");
+
+  const output = prepare(path, "schedule", "1783339200");
+
+  assert.equal(output.release, "true");
+  assert.equal(output.version, "2026.07.06.2");
+  assert.equal(output.latest_tag, "2026.07.06.1");
+});
+
+test("increments past single digits with lightweight tags", (t) => {
+  const path = repository();
+  t.after(() => rmSync(path, { force: true, recursive: true }));
+
+  commit(path, "released", "2026-07-04T12:00:00Z");
+  git(path, "tag", "2026.07.06.9");
+  commit(path, "next", "2026-07-05T12:00:00Z");
+
+  const output = prepare(path, "schedule", "1783339200");
+
+  assert.equal(output.release, "true");
+  assert.equal(output.version, "2026.07.06.10");
+  assert.equal(output.latest_tag, "2026.07.06.9");
+});
+
+test("avoids a sequence held by an unreachable same-date tag", (t) => {
+  const path = repository();
+  t.after(() => rmSync(path, { force: true, recursive: true }));
+
+  commit(path, "base", "2026-07-01T12:00:00Z");
+  git(path, "checkout", "-b", "side");
+  commit(path, "side", "2026-07-02T12:00:00Z");
+  git(path, "tag", "2026.07.06.1");
+  git(path, "checkout", "main");
+  commit(path, "main", "2026-07-03T12:00:00Z");
+
+  const output = prepare(path, "schedule", "1783339200");
+
+  assert.equal(output.release, "true");
+  assert.equal(output.latest_tag, "");
+  assert.equal(output.version, "2026.07.06.2");
+});
+
+test("skips when the latest release already contains the candidate", (t) => {
+  const path = repository();
+  t.after(() => rmSync(path, { force: true, recursive: true }));
+
+  commit(path, "released", "2026-07-04T12:00:00Z");
+  tag(path, "2026.07.05.1");
+
+  const output = prepare(path, "schedule", "1783339200");
+
+  assert.equal(output.release, "false");
+  assert.equal(output.reason, "No commits since 2026.07.05.1.");
+});
+
+test("manual releases also skip when there are no new commits", (t) => {
+  const path = repository();
+  t.after(() => rmSync(path, { force: true, recursive: true }));
+
+  commit(path, "released", "2026-07-04T12:00:00Z");
+  tag(path, "2026.07.05.1");
+
+  const output = prepare(path, "workflow_dispatch", "1783339200");
+
+  assert.equal(output.release, "false");
+  assert.equal(output.reason, "No commits since 2026.07.05.1.");
+});
+
+test("scheduled releases require 24 hours of bake time", (t) => {
+  const path = repository();
+  t.after(() => rmSync(path, { force: true, recursive: true }));
+
+  commit(path, "recent", "2026-07-06T11:00:00Z");
+
+  const output = prepare(path, "schedule", "1783339200");
+
+  assert.equal(output.release, "false");
+  assert.equal(
+    output.reason,
+    "Candidate commit is 3600 seconds old; scheduled releases require 86400 seconds.",
+  );
+});
+
+test("manual releases bypass the bake-time requirement", (t) => {
+  const path = repository();
+  t.after(() => rmSync(path, { force: true, recursive: true }));
+
+  commit(path, "urgent fix", "2026-07-06T11:00:00Z");
+
+  const output = prepare(path, "workflow_dispatch", "1783339200");
+
+  assert.equal(output.release, "true");
+  assert.equal(output.version, "2026.07.06.1");
+});
+
+test("clamps a future-dated candidate age to zero", (t) => {
+  const path = repository();
+  t.after(() => rmSync(path, { force: true, recursive: true }));
+
+  // Committer date one hour ahead of RELEASE_NOW (clock skew).
+  commit(path, "future", "2026-07-06T13:00:00Z");
+
+  const output = prepare(path, "workflow_dispatch", "1783339200");
+
+  assert.equal(output.candidate_age_seconds, "0");
+  assert.equal(output.release, "true");
+});
+
+test("internal Homebrew/actions dependencies use full commit SHAs", () => {
+  const actionFiles = git(REPOSITORY_ROOT, "ls-files")
+    .split("\n")
+    .filter((file) => file.endsWith("/action.yml"));
+  const invalidReferences: string[] = [];
+
+  for (const actionFile of actionFiles) {
+    const action = yaml.load(
+      readFileSync(join(REPOSITORY_ROOT, actionFile), "utf8"),
+    ) as ActionMetadata;
+
+    for (const step of action.runs?.steps ?? []) {
+      if (
+        step.uses?.startsWith("Homebrew/actions/") &&
+        !/^Homebrew\/actions\/[^@]+@[0-9a-f]{40}$/.test(step.uses)
+      ) {
+        invalidReferences.push(`${actionFile}: ${step.uses}`);
+      }
+    }
+  }
+
+  assert.deepEqual(invalidReferences, []);
+});
+
+test("internal Homebrew/actions pins reference the current sub-action tree", () => {
+  const actionFiles = git(REPOSITORY_ROOT, "ls-files")
+    .split("\n")
+    .filter((file) => file.endsWith("/action.yml"));
+  const staleReferences: string[] = [];
+
+  for (const actionFile of actionFiles) {
+    const action = yaml.load(
+      readFileSync(join(REPOSITORY_ROOT, actionFile), "utf8"),
+    ) as ActionMetadata;
+
+    for (const step of action.runs?.steps ?? []) {
+      const match = step.uses?.match(
+        /^Homebrew\/actions\/([^@]+)@([0-9a-f]{40})$/,
+      );
+      if (!match) continue;
+
+      const [, subAction, sha] = match;
+      const changedFiles = git(
+        REPOSITORY_ROOT,
+        "diff",
+        "--name-only",
+        `${sha}..HEAD`,
+        "--",
+        `${subAction}/`,
+      );
+      if (changedFiles) {
+        staleReferences.push(
+          `${actionFile}: ${step.uses} is behind ${subAction}/`,
+        );
+      }
+    }
+  }
+
+  assert.deepEqual(staleReferences, []);
+});

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Set up Homebrew
       if: inputs.setup-homebrew == 'true'
-      uses: Homebrew/actions/setup-homebrew@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
+      uses: Homebrew/actions/setup-homebrew@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
       with:
         debug: ${{ inputs.debug }}
 

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Set up Homebrew
       if: inputs.setup-homebrew == 'true'
-      uses: Homebrew/actions/setup-homebrew@main
+      uses: Homebrew/actions/setup-homebrew@24728b77430f9659b8d89068e4afe7f5fd0f973c # main
       with:
         debug: ${{ inputs.debug }}
 


### PR DESCRIPTION
Release all the Actions in this repo together under bare CalVer tags (`YYYY.MM.DD.N`, where `N` restarts at 1 each UTC day), the same lightweight-tag + `gh release create` model `Homebrew/brew` uses. The one difference is that we pin `--target` to the exact `main` SHA captured at checkout instead of trusting whatever the default branch points at when the release publishes.

A scheduled workflow runs every Monday at 12:00 UTC and can also be dispatched manually for an urgent fix. It skips when nothing has changed since the latest CalVer tag; scheduled runs additionally wait for the candidate commit to bake for 24h (manual dispatch skips that wait but still won't cut a no-op release). GitHub creates the tag and generated notes; existing tags are never moved or reused.

The six internal `Homebrew/actions/…@main` references in `pre-build`, `setup-ruby`, `bump-formulae`, and `post-build` are now pinned to full SHAs so a released snapshot never resolves `@main` at runtime. Two tests keep those pins honest: one rejects any internal dependency that isn't a 40-char SHA, the other fails if a pin falls behind its sub-action's current tree. `test.yml` fetches full history so that freshness check can resolve the pinned SHAs.