### PR TITLE
release: repin internal actions to 2026.07.10.1

### DIFF
--- a/bump-formulae/action.yml
+++ b/bump-formulae/action.yml
@@ -22,7 +22,7 @@ runs:
     - run: echo "::warning::Homebrew/actions/bump-formulae is deprecated. Please use Homebrew/actions/bump-packages instead."
       shell: sh
 
-    - uses: Homebrew/actions/bump-packages@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
+    - uses: Homebrew/actions/bump-packages@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
       with:
         token: ${{ inputs.token }}
         formulae: ${{ inputs.formulae }}

--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Failures summary for brew test-bot
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
+      uses: Homebrew/actions/failures-summary-and-bottle-result@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: steps_output.txt
@@ -36,7 +36,7 @@ runs:
 
     - name: Output brew linkage result
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
+      uses: Homebrew/actions/failures-summary-and-bottle-result@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: linkage_output.txt
@@ -45,7 +45,7 @@ runs:
 
     - name: Output brew bottle result
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
+      uses: Homebrew/actions/failures-summary-and-bottle-result@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: bottle_output.txt

--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Set up Homebrew
       id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
+      uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
       with:
         core: true
         cask: true

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Set up Homebrew
       if: inputs.setup-homebrew == 'true'
-      uses: Homebrew/actions/setup-homebrew@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # main
+      uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
       with:
         debug: ${{ inputs.debug }}
 


### PR DESCRIPTION
Repin the six internal `Homebrew/actions` references to the first immutable CalVer release, `2026.07.10.1`.

Internal references intentionally target the previous immutable release rather than `main`, ensuring released composite actions have no mutable transitive dependencies.