### PR TITLE
Enforce responsible AI commit attribution

### DIFF
--- a/check-commit-format/README.md
+++ b/check-commit-format/README.md
@@ -1,6 +1,8 @@
 # Check commit format GitHub Action
 
-An action that checks that a pull request's commits follow [Homebrew's commit style guidelines](https://docs.brew.sh/Formula-Cookbook#commit).
+An action that rejects conventional commit prefixes and commits that attribute
+authorship or other credit to AI tools. By default, it also checks that package
+commits follow [Homebrew's commit style guidelines](https://docs.brew.sh/Formula-Cookbook#commit).
 
 ## Usage
 
@@ -10,3 +12,6 @@ An action that checks that a pull request's commits follow [Homebrew's commit st
   with:
     token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
 ```
+
+Set `check_package_commit_format: false` when using the action in a repository
+that does not contain formulae or casks.

--- a/check-commit-format/action.yml
+++ b/check-commit-format/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Label to set to make this action ignore the pull request. Default is CI-published-bottle-commits
     required: false
     default: CI-published-bottle-commits
+  check_package_commit_format:
+    description: Check Homebrew formula or cask commit format and manage related labels
+    required: false
+    default: true
 runs:
   using: node24
   main: main.mts

--- a/check-commit-format/main.mts
+++ b/check-commit-format/main.mts
@@ -8,12 +8,16 @@ import path from "path"
 
 import type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods"
 
+const conventionalCommitPattern = /^(feat|fix|chore|refactor|perf|ci)(\([^)]*\))?!?:/
+const aiIdentityPattern = /chatgpt|github[ \t-]*copilot|copilot@(github\.com|users\.noreply\.github\.com)|claude[ \t-]+code|noreply@anthropic\.com|gemini([ \t-]+cli)?|codex|noreply@openai\.com|cursor([ \t-]+agent)?|devin[ \t-]+ai|coderabbit|codeium|windsurf|sourcegraph[ \t-]+cody|amazon[ \t-]+q|artificial[ \t-]+intelligence|large[ \t-]+language[ \t-]+model|(^|[^a-z0-9])(ai|llm)[ \t-]+(agent|assistant|bot|tool)([^a-z0-9]|$)/i
+
 async function main() {
     try {
         const token = core.getInput("token", { required: true })
         const failure_label = core.getInput("failure_label", { required: true })
         const autosquash_label = core.getInput("autosquash_label", { required: true })
         const ignore_label = core.getInput("ignore_label", { required: true })
+        const check_package_commit_format = core.getBooleanInput("check_package_commit_format", { required: true })
 
         const client = github.getOctokit(token)
 
@@ -34,7 +38,13 @@ async function main() {
         let commit_state: RestEndpointMethodTypes["repos"]["createCommitStatus"]["parameters"]["state"] = "success"
         let message = "Commit format is correct."
         let files_touched: Array<string> = []
-        let target_url = "https://docs.brew.sh/Formula-Cookbook#commit"
+        let target_url = `https://github.com/${github.context.repo.owner}/${github.context.repo.repo}/blob/HEAD/CONTRIBUTING.md`
+        if (check_package_commit_format) {
+            target_url = "https://docs.brew.sh/Formula-Cookbook#commit"
+        }
+        if (github.context.repo.repo === "homebrew-cask") {
+            target_url = "https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#style-guide"
+        }
 
         // For each commit...
         for (const commit of commits.data) {
@@ -44,6 +54,46 @@ async function main() {
             })
 
             const short_sha = commit.sha.substring(0, 10);
+            const commit_message = commit_info.data.commit.message
+            const identities = [
+                commit_info.data.commit.author?.name,
+                commit_info.data.commit.author?.email,
+                commit_info.data.commit.committer?.name,
+                commit_info.data.commit.committer?.email,
+            ].filter(Boolean).join("\n")
+
+            if (aiIdentityPattern.test(identities)) {
+                is_success = false
+                commit_state = "failure"
+                message = "AI author or committer attribution is not allowed."
+                break
+            }
+
+            const message_lines = commit_message.trimEnd().split(/\r?\n/)
+            let trailer_start = message_lines.length
+            while (trailer_start > 0 &&
+                   (/^[A-Za-z0-9-]+:\s+\S/.test(message_lines[trailer_start - 1]) ||
+                    /^[ \t]+\S/.test(message_lines[trailer_start - 1]))) {
+                trailer_start--
+            }
+            if (trailer_start > 0 && message_lines[trailer_start - 1].trim() === "" &&
+                aiIdentityPattern.test(message_lines.slice(trailer_start).join("\n"))) {
+                is_success = false
+                commit_state = "failure"
+                message = "AI commit trailer attribution is not allowed."
+                break
+            }
+
+            if (conventionalCommitPattern.test(commit_message.split("\n")[0])) {
+                is_success = false
+                commit_state = "failure"
+                message = "Conventional commit prefixes are not allowed."
+                break
+            }
+
+            if (!check_package_commit_format) {
+                continue
+            }
 
             // Autosquash doesn't support merge commits.
             if (commit_info.data.parents.length != 1) {
@@ -86,7 +136,7 @@ async function main() {
             }
 
             const file = commit_info.data.files[0]
-            const commit_subject = commit_info.data.commit.message.split("\n")[0]
+            const commit_subject = commit_message.split("\n")[0]
 
             if (file.filename.startsWith("Formula/")) {
                 const formula = path.basename(file.filename, '.rb')
@@ -130,6 +180,10 @@ async function main() {
             context: "Commit style",
             target_url: target_url
         })
+
+        if (!check_package_commit_format) {
+            return
+        }
 
         // Get existing labels on PR
         let issueLabels = await client.rest.issues.listLabelsOnIssue({

--- a/check-commit-format/main.test.mts
+++ b/check-commit-format/main.test.mts
@@ -16,6 +16,7 @@ describe("check-commit-format", async () => {
     mockInput("failure_label", failureLabel)
     mockInput("autosquash_label", autosquashLabel)
     mockInput("ignore_label", ignoreLabel)
+    mockInput("check_package_commit_format", "true")
 
     const tempdir = fs.mkdtempSync(path.join(os.tmpdir(), "check-commit-format-"))
     const tempfile = `${tempdir}/event.json`
@@ -404,6 +405,155 @@ describe("check-commit-format", async () => {
       ])
 
       await loadMain()
+    })
+  })
+
+  describe("in Homebrew/brew", () => {
+    type Identity = { name: string, email: string }
+
+    async function checkCommit(
+      message: string,
+      author: Identity,
+      committer: Identity,
+      files: Array<{ filename: string }>,
+      state: "success" | "failure",
+      description: string,
+    ) {
+      const repository = "Homebrew/brew"
+      process.env.GITHUB_REPOSITORY = repository
+      mockInput("check_package_commit_format", "false")
+
+      const mockPool = githubMockPool()
+      mockPool.intercept({
+        method: "GET",
+        path: `/repos/${repository}/pulls/${pr}/commits`,
+        headers: {
+          Authorization: `token ${token}`,
+        },
+      }).defaultReplyHeaders({
+        "Content-Type": "application/json",
+      }).reply(200, [{ sha: sha }])
+
+      mockPool.intercept({
+        method: "GET",
+        path: `/repos/${repository}/commits/${sha}`,
+        headers: {
+          Authorization: `token ${token}`,
+        },
+      }).defaultReplyHeaders({
+        "Content-Type": "application/json",
+      }).reply(200, {
+        sha: sha,
+        parents: [{ sha: "abcdef1234567890abcdef1234567890abcdef11" }],
+        files: files,
+        commit: {
+          message: message,
+          author: author,
+          committer: committer,
+        },
+      })
+
+      mockPool.intercept({
+        method: "POST",
+        path: `/repos/${repository}/statuses/${sha}`,
+        headers: {
+          Authorization: `token ${token}`,
+        },
+        body: (body) => util.isDeepStrictEqual(JSON.parse(body), {
+          state:       state,
+          description: description,
+          context:     "Commit style",
+          target_url:  "https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md",
+        }),
+      }).defaultReplyHeaders({
+        "Content-Type": "application/json",
+      }).reply(200, {})
+
+      await loadMain()
+    }
+
+    const contributor = { name: "Homebrew Contributor", email: "contributor@example.com" }
+    const disallowedCommits = [
+      {
+        name: "an AI author email",
+        message: "Improve checks",
+        author: { name: "Coding Assistant", email: "175728472+Copilot@users.noreply.github.com" },
+        committer: contributor,
+        description: "AI author or committer attribution is not allowed.",
+      },
+      {
+        name: "an AI committer",
+        message: "Improve checks",
+        author: contributor,
+        committer: { name: "Codex", email: "noreply@openai.com" },
+        description: "AI author or committer attribution is not allowed.",
+      },
+      {
+        name: "an AI commit trailer",
+        message: "Improve checks\n\nCo-authored-by: Coding Assistant <copilot@github.com>",
+        author: contributor,
+        committer: contributor,
+        description: "AI commit trailer attribution is not allowed.",
+      },
+      {
+        name: "a generic AI assistant trailer",
+        message: "Improve checks\n\nCo-authored-by: AI Assistant <assistant@example.com>",
+        author: contributor,
+        committer: contributor,
+        description: "AI commit trailer attribution is not allowed.",
+      },
+      {
+        name: "an AI signatory",
+        message: "Improve checks\n\nSigned-off-by: Codex <noreply@openai.com>",
+        author: contributor,
+        committer: contributor,
+        description: "AI commit trailer attribution is not allowed.",
+      },
+      {
+        name: "an assisted-by AI trailer",
+        message: "Improve checks\n\nAssisted-by: Claude Code <noreply@anthropic.com>",
+        author: contributor,
+        committer: contributor,
+        description: "AI commit trailer attribution is not allowed.",
+      },
+      {
+        name: "a co-developed-by AI trailer",
+        message: "Improve checks\n\nCo-developed-by: Gemini CLI <gemini-cli@google.com>",
+        author: contributor,
+        committer: contributor,
+        description: "AI commit trailer attribution is not allowed.",
+      },
+      {
+        name: "a conventional commit prefix",
+        message: "fix: improve checks",
+        author: contributor,
+        committer: contributor,
+        description: "Conventional commit prefixes are not allowed.",
+      },
+    ]
+
+    for (const commit of disallowedCommits) {
+      it(`rejects ${commit.name}`, async () => {
+        await checkCommit(
+          commit.message,
+          commit.author,
+          commit.committer,
+          [{ filename: "README.md" }],
+          "failure",
+          commit.description,
+        )
+      })
+    }
+
+    it("does not enforce package repository commit rules", async () => {
+      await checkCommit(
+        "Document ChatGPT support\n\nCo-authored-by: Another Contributor <another@example.com>",
+        { name: "Claude Dupont", email: "claude@example.com" },
+        contributor,
+        [{ filename: "README.md" }, { filename: "docs/FAQ.md" }],
+        "success",
+        "Commit format is correct.",
+      )
     })
   })
 })


### PR DESCRIPTION
- Apply attribution and prefix checks to every consumer
- Allow non-package repositories to skip formula and cask rules

Migrated from https://github.com/Homebrew/brew/pull/23317