### PR TITLE
Add reusable licence workflow

### DIFF
--- a/.github/denied-licenses.txt
+++ b/.github/denied-licenses.txt
@@ -1,0 +1,5 @@
+# SPDX licences denied for every dependency ecosystem.
+AGPL-1.0-only
+AGPL-1.0-or-later
+AGPL-3.0-only
+AGPL-3.0-or-later

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -1,0 +1,83 @@
+name: Licenses
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  merge_group:
+  workflow_call:
+    inputs:
+      ecosystems_from:
+        description: Email address sent to ecosyste.ms in the From header
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  licenses:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
+
+      - name: Install git-pkgs
+        run: brew install git-pkgs
+
+      - name: Cache git-pkgs licence metadata
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/git-pkgs
+          key: git-pkgs-metadata-v1-${{ hashFiles('**/uv.lock', '**/requirements*.txt', '**/pyproject.toml', '**/package-lock.json', '**/pnpm-lock.yaml', '**/yarn.lock', '**/Gemfile.lock', '**/go.sum', '**/Cargo.lock', '**/composer.lock') }}-${{ github.run_id }}
+          restore-keys: |
+            git-pkgs-metadata-v1-${{ hashFiles('**/uv.lock', '**/requirements*.txt', '**/pyproject.toml', '**/package-lock.json', '**/pnpm-lock.yaml', '**/yarn.lock', '**/Gemfile.lock', '**/go.sum', '**/Cargo.lock', '**/composer.lock') }}-
+            git-pkgs-metadata-v1-
+
+      - name: Read denied licences
+        run: |
+          denied="$(sed -E \
+            '/^[[:space:]]*(#|$)/d; s/^[[:space:]]*//; s/[[:space:]]*$//' \
+            .github/denied-licenses.txt | paste -sd, -)"
+          echo "Denied licences: ${denied}"
+          echo "DENIED_LICENSES=${denied}" >> "${GITHUB_ENV}"
+
+      - name: Check licences
+        env:
+          GIT_PKGS_DB: ${{ runner.temp }}/git-pkgs/metadata.db
+          GIT_PKGS_ECOSYSTEMS_FROM: ${{ inputs.ecosystems_from }}
+        run: |
+          output="${RUNNER_TEMP}/licenses.json"
+          status=0
+          git pkgs licenses --format=json \
+            --deny="${DENIED_LICENSES}" > "${output}" || status="$?"
+          if ! jq -e 'type == "array"' "${output}" &>/dev/null; then
+            echo "git pkgs licenses failed:"
+            cat "${output}"
+            if ((status == 0)); then
+              exit 1
+            fi
+            exit "${status}"
+          fi
+
+          violations="$(jq -r \
+            '.[] | select(.flagged) | . as $dep |
+            "\($dep.name) (\($dep.ecosystem)) \($dep.version // "?"): \($dep.licenses | join(", ")) - \($dep.flag_reason)"' \
+            "${output}")"
+          if [ -n "${violations}" ]; then
+            echo "Dependencies with denied licences:"
+            echo "${violations}"
+            exit 1
+          fi
+          echo "No denied licences found in $(jq length "${output}") dependencies."

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/denied-licenses.txt  @Homebrew/lead-maintainers @MikeMcQuaid


### PR DESCRIPTION
- Check this repository and callers against their licence denylists.
- Cache git-pkgs metadata between workflow runs.
- Allow callers to identify themselves to ecosyste.ms.