### PR TITLE
setup-homebrew: output tap name

### DIFF
--- a/release.test.mts
+++ b/release.test.mts
@@ -248,11 +248,13 @@ test("internal Homebrew/actions dependencies use full commit SHAs", () => {
   assert.deepEqual(invalidReferences, []);
 });
 
-test("internal Homebrew/actions pins reference the current sub-action tree", () => {
+// Pin freshness is Dependabot's job; requiring pins to match the current tree
+// would force pull requests to repin to their own yet-unmerged commits.
+test("internal Homebrew/actions pins reference reachable commits", () => {
   const actionFiles = git(REPOSITORY_ROOT, "ls-files")
     .split("\n")
     .filter((file) => file.endsWith("/action.yml"));
-  const staleReferences: string[] = [];
+  const unreachableReferences: string[] = [];
 
   for (const actionFile of actionFiles) {
     const action = yaml.load(
@@ -260,28 +262,24 @@ test("internal Homebrew/actions pins reference the current sub-action tree", () 
     ) as ActionMetadata;
 
     for (const step of action.runs?.steps ?? []) {
-      const match = step.uses?.match(
-        /^Homebrew\/actions\/([^@]+)@([0-9a-f]{40})$/,
-      );
+      const match = step.uses?.match(/^Homebrew\/actions\/[^@]+@([0-9a-f]{40})$/);
       if (!match) continue;
 
-      const [, subAction, sha] = match;
-      const changedFiles = git(
+      const ancestor = spawnSync("git", [
+        "-C",
         REPOSITORY_ROOT,
-        "diff",
-        "--name-only",
-        `${sha}..HEAD`,
-        "--",
-        `${subAction}/`,
-        `:(exclude)${subAction}/README.md`,
-      );
-      if (changedFiles) {
-        staleReferences.push(
-          `${actionFile}: ${step.uses} is behind ${subAction}/`,
+        "merge-base",
+        "--is-ancestor",
+        match[1],
+        "HEAD",
+      ]);
+      if (ancestor.status !== 0) {
+        unreachableReferences.push(
+          `${actionFile}: ${step.uses} is not an ancestor of HEAD`,
         );
       }
     }
   }
 
-  assert.deepEqual(staleReferences, []);
+  assert.deepEqual(unreachableReferences, []);
 });

--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -36,6 +36,8 @@ inputs:
 outputs:
   repository-path:
     description: Path to where the repository has been checked out (if applicable)
+  tap-name:
+    description: Name of the tap, e.g. `user/repository` for `user/homebrew-repository` (if applicable)
   gems-path:
     description: Homebrew's Ruby gems path
   gems-hash:

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -209,6 +209,7 @@ else
 
     if [[ -n "${HOMEBREW_TAP_REPOSITORY-}" ]]; then
         echo "repository-path=$HOMEBREW_TAP_REPOSITORY" >>"$GITHUB_OUTPUT"
+        echo "tap-name=$HOMEBREW_TAP_NAME" >>"$GITHUB_OUTPUT"
     fi
 fi
 if [[ "${STABLE}" == "true" && ! "$GITHUB_REPOSITORY" =~ ^.+/brew$ ]]; then


### PR DESCRIPTION
Expose the already-computed `HOMEBREW_TAP_NAME` as a `tap-name` output so tap workflows, e.g. the `brew tap-new` autobump workflow from Homebrew/brew#23349, can use it instead of hardcoding it.

Closes https://github.com/Homebrew/actions/pull/904