### PR TITLE
Use self-repository syntax for internal actions

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,9 @@ self-hosted-runner:
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.
 config-variables: []
+paths:
+  .github/workflows/**/*.yml:
+    ignore:
+      # actionlint does not yet understand the self-repository (`$/`) syntax:
+      # https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/
+      - 'specifying action "\$/[^"]+" in invalid format because ref is missing'

--- a/.github/workflows/cache-homebrew-prefix.yml
+++ b/.github/workflows/cache-homebrew-prefix.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Homebrew
-        uses: ./setup-homebrew/
+        uses: $/setup-homebrew
 
       - name: Ensure empty Homebrew formulae
         run: |
@@ -36,7 +36,7 @@ jobs:
 
       - name: Cache Homebrew prefix with uninstall
         id: cache-homebrew-prefix-install
-        uses: ./cache-homebrew-prefix/
+        uses: $/cache-homebrew-prefix
         with:
           install: wget jq
           uninstall: true
@@ -69,7 +69,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Homebrew
-        uses: ./setup-homebrew/
+        uses: $/setup-homebrew
 
       - name: Ensure empty Homebrew formulae
         run: |
@@ -93,7 +93,7 @@ jobs:
 
       - name: Cache Homebrew prefix from Brewfile with uninstall
         id: cache-homebrew-prefix-brewfile
-        uses: ./cache-homebrew-prefix/
+        uses: $/cache-homebrew-prefix
         with:
           brewfile: true
           uninstall: true

--- a/.github/workflows/git-try-push.yml
+++ b/.github/workflows/git-try-push.yml
@@ -34,7 +34,7 @@ jobs:
           git checkout -
 
       - name: Push
-        uses: ./git-try-push/
+        uses: $/git-try-push
         with:
           remote: local-remote
           branch: test-try-push

--- a/.github/workflows/git-user-config.yml
+++ b/.github/workflows/git-user-config.yml
@@ -14,14 +14,9 @@ jobs:
   user-config:
     runs-on: ubuntu-slim
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Config
         id: config
-        uses: ./git-user-config/
+        uses: $/git-user-config
         with:
           username: BrewTestBot
 

--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -34,7 +34,7 @@ jobs:
       image: ghcr.io/homebrew/brew:main
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
+        uses: $/setup-homebrew
         with:
           core: false
           cask: false
@@ -97,7 +97,7 @@ jobs:
 
       - name: Remove disabled packages
         id: remove
-        uses: ./remove-disabled-packages/
+        uses: $/remove-disabled-packages
 
       - name: Verify only the long-disabled formula was removed
         env:

--- a/.github/workflows/setup-commit-signing.yml
+++ b/.github/workflows/setup-commit-signing.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Configure git user
         id: git-config
-        uses: ./git-user-config/
+        uses: $/git-user-config
         with:
           username: BrewTestBot
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Set up commit signing
         id: set-up-commit-signing
-        uses: ./setup-commit-signing/
+        uses: $/setup-commit-signing
         with:
           signing_key: ${{ steps.generate-ssh-key.outputs.key }}
 

--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: ./setup-homebrew/
+        uses: $/setup-homebrew
         with:
           stable: ${{ matrix.stable }}
 

--- a/.github/workflows/setup-ruby.yml
+++ b/.github/workflows/setup-ruby.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Set up Ruby
         id: set-up-ruby
-        uses: ./setup-ruby/
+        uses: $/setup-ruby
         with:
           setup-homebrew: true
           portable-ruby: ${{ matrix.portable }}
@@ -73,7 +73,7 @@ jobs:
           fi
 
       - name: Set up Ruby from subdirectory
-        uses: ./setup-ruby/
+        uses: $/setup-ruby
         with:
           working-directory: setup-ruby
 
@@ -103,7 +103,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Ruby for bundler-cache test prep
-        uses: ./setup-ruby/
+        uses: $/setup-ruby
         with:
           setup-homebrew: true
           portable-ruby: ${{ matrix.portable }}
@@ -120,14 +120,14 @@ jobs:
         run: bundle lock
 
       - name: Set up Ruby with Bundler cache
-        uses: ./setup-ruby/
+        uses: $/setup-ruby
         with:
           setup-homebrew: true
           portable-ruby: ${{ matrix.portable }}
           bundler-cache: true
 
       - name: Run setup-ruby again with Bundler cache
-        uses: ./setup-ruby/
+        uses: $/setup-ruby
         with:
           setup-homebrew: true
           portable-ruby: ${{ matrix.portable }}

--- a/.github/workflows/sync-default-branches.yml
+++ b/.github/workflows/sync-default-branches.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
     steps:
       - name: Configure Git user
-        uses: Homebrew/actions/git-user-config@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
+        uses: $/git-user-config
         with:
           username: github-actions[bot]
 

--- a/.github/workflows/vendor-node-modules.yml
+++ b/.github/workflows/vendor-node-modules.yml
@@ -31,11 +31,11 @@ jobs:
         with:
           node-version: '24'
       - name: Configure Git user
-        uses: ./git-user-config/
+        uses: $/git-user-config
         with:
           username: BrewTestBot
       - name: Set up commit signing
-        uses: ./setup-commit-signing/
+        uses: $/setup-commit-signing
         with:
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
       - name: Check out pull request
@@ -60,7 +60,7 @@ jobs:
           fi
       - name: Push to pull request
         if: steps.commit.outputs.committed == 'true'
-        uses: ./git-try-push/
+        uses: $/git-try-push
         with:
           token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           branch: ${{ steps.checkout.outputs.branch }}

--- a/bump-formulae/action.yml
+++ b/bump-formulae/action.yml
@@ -22,7 +22,7 @@ runs:
     - run: echo "::warning::Homebrew/actions/bump-formulae is deprecated. Please use Homebrew/actions/bump-packages instead."
       shell: sh
 
-    - uses: Homebrew/actions/bump-packages@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
+    - uses: $/bump-packages
       with:
         token: ${{ inputs.token }}
         formulae: ${{ inputs.formulae }}

--- a/post-build/action.yml
+++ b/post-build/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Failures summary for brew test-bot
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
+      uses: $/failures-summary-and-bottle-result
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: steps_output.txt
@@ -36,7 +36,7 @@ runs:
 
     - name: Output brew linkage result
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
+      uses: $/failures-summary-and-bottle-result
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: linkage_output.txt
@@ -45,7 +45,7 @@ runs:
 
     - name: Output brew bottle result
       if: always()
-      uses: Homebrew/actions/failures-summary-and-bottle-result@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
+      uses: $/failures-summary-and-bottle-result
       with:
         workdir: ${{ inputs.bottles-directory }}
         result_path: bottle_output.txt

--- a/pre-build/action.yml
+++ b/pre-build/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Set up Homebrew
       id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
+      uses: $/setup-homebrew
       with:
         core: true
         cask: true

--- a/release.test.mts
+++ b/release.test.mts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import {
   appendFileSync,
+  existsSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -21,6 +22,10 @@ type ActionMetadata = {
   runs?: {
     steps?: ActionStep[];
   };
+};
+
+type WorkflowMetadata = {
+  jobs?: Record<string, { steps?: ActionStep[] }>;
 };
 
 const REPOSITORY_ROOT = fileURLToPath(new URL(".", import.meta.url));
@@ -224,7 +229,7 @@ test("clamps a future-dated candidate age to zero", (t) => {
   assert.equal(output.release, "true");
 });
 
-test("internal Homebrew/actions dependencies use full commit SHAs", () => {
+test("internal action references use self-repository syntax", () => {
   const actionFiles = git(REPOSITORY_ROOT, "ls-files")
     .split("\n")
     .filter((file) => file.endsWith("/action.yml"));
@@ -237,8 +242,8 @@ test("internal Homebrew/actions dependencies use full commit SHAs", () => {
 
     for (const step of action.runs?.steps ?? []) {
       if (
-        step.uses?.startsWith("Homebrew/actions/") &&
-        !/^Homebrew\/actions\/[^@]+@[0-9a-f]{40}$/.test(step.uses)
+        step.uses?.startsWith("Homebrew/actions/") ||
+        step.uses?.startsWith("./")
       ) {
         invalidReferences.push(`${actionFile}: ${step.uses}`);
       }
@@ -248,38 +253,36 @@ test("internal Homebrew/actions dependencies use full commit SHAs", () => {
   assert.deepEqual(invalidReferences, []);
 });
 
-// Pin freshness is Dependabot's job; requiring pins to match the current tree
-// would force pull requests to repin to their own yet-unmerged commits.
-test("internal Homebrew/actions pins reference reachable commits", () => {
-  const actionFiles = git(REPOSITORY_ROOT, "ls-files")
+test("self-repository references target existing actions", () => {
+  const files = git(REPOSITORY_ROOT, "ls-files")
     .split("\n")
-    .filter((file) => file.endsWith("/action.yml"));
-  const unreachableReferences: string[] = [];
+    .filter(
+      (file) =>
+        file.endsWith("/action.yml") ||
+        (file.startsWith(".github/workflows/") && file.endsWith(".yml")),
+    );
+  const brokenReferences: string[] = [];
 
-  for (const actionFile of actionFiles) {
-    const action = yaml.load(
-      readFileSync(join(REPOSITORY_ROOT, actionFile), "utf8"),
-    ) as ActionMetadata;
-
-    for (const step of action.runs?.steps ?? []) {
-      const match = step.uses?.match(/^Homebrew\/actions\/[^@]+@([0-9a-f]{40})$/);
-      if (!match) continue;
-
-      const ancestor = spawnSync("git", [
-        "-C",
-        REPOSITORY_ROOT,
-        "merge-base",
-        "--is-ancestor",
-        match[1],
-        "HEAD",
-      ]);
-      if (ancestor.status !== 0) {
-        unreachableReferences.push(
-          `${actionFile}: ${step.uses} is not an ancestor of HEAD`,
+  for (const file of files) {
+    const parsed = yaml.load(readFileSync(join(REPOSITORY_ROOT, file), "utf8"));
+    const steps = file.endsWith("/action.yml")
+      ? ((parsed as ActionMetadata).runs?.steps ?? [])
+      : Object.values((parsed as WorkflowMetadata).jobs ?? {}).flatMap(
+          (job) => job.steps ?? [],
         );
+
+    for (const step of steps) {
+      if (!step.uses?.startsWith("$/")) continue;
+
+      const subAction = step.uses.slice("$/".length);
+      if (
+        !/^[a-z][a-z-]*$/.test(subAction) ||
+        !existsSync(join(REPOSITORY_ROOT, subAction, "action.yml"))
+      ) {
+        brokenReferences.push(`${file}: ${step.uses}`);
       }
     }
   }
 
-  assert.deepEqual(unreachableReferences, []);
+  assert.deepEqual(brokenReferences, []);
 });

--- a/setup-ruby/action.yml
+++ b/setup-ruby/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Set up Homebrew
       if: inputs.setup-homebrew == 'true'
-      uses: Homebrew/actions/setup-homebrew@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
+      uses: $/setup-homebrew
       with:
         debug: ${{ inputs.debug }}
 


### PR DESCRIPTION
Blocked on https://github.com/zizmorcore/zizmor/issues/2248
Blocked on all Homebrew self-hosted runners being on runner version ≥ 2.336.0

- GitHub now resolves `$/name` references to this repository at the commit that is running, so internal references can no longer lag behind the latest release or require a checkout: https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/
- Replace pinned `Homebrew/actions/*` and checked-out `./*` internal references in composite actions and workflows with `$/*`.
- Leave workflows synced from the `.github` repository unchanged as they run in other repositories where `$/` resolves elsewhere.
- Drop the checkout that only served `./git-user-config/` in its test.
- Replace the release test SHA pin checks, which `$/` obsoletes, with checks that internal references use `$/` and target real actions.
- Ignore actionlint's invalid-format error for `$/` references until actionlint understands the new syntax.