### PR TITLE
Replace commit status with workflow result

### DIFF
--- a/check-commit-format/README.md
+++ b/check-commit-format/README.md
@@ -7,11 +7,33 @@ commits follow [Homebrew's commit style guidelines](https://docs.brew.sh/Formula
 ## Usage
 
 ```yaml
-- name: Check commit style
-  uses: Homebrew/actions/check-commit-format@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
-  with:
-    token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  check-commit-style:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commit style
+        uses: Homebrew/actions/check-commit-format@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
 ```
+
+When the `token` input is omitted, the action uses `${{ github.token }}` and the
+workflow `permissions:` block shown above grants it `contents: read`,
+`pull-requests: read` and `issues: write` for package-repository label
+management. GitHub downgrades write access for fork pull requests.
+
+The workflow `permissions:` block does not grant permissions to a custom token
+passed with `token`. Grant that token equivalent repository permissions or
+scopes directly.
 
 Set `check_package_commit_format: false` when using the action in a repository
 that does not contain formulae or casks.
+
+When migrating from the legacy `Commit style` status, update branch protection
+rules or rulesets to require the workflow job instead.

--- a/check-commit-format/main.mts
+++ b/check-commit-format/main.mts
@@ -6,8 +6,6 @@ import * as github from "@actions/github"
 import fs from "fs"
 import path from "path"
 
-import type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods"
-
 const conventionalCommitPattern = /^(feat|fix|chore|refactor|perf|ci)(\([^)]*\))?!?:/
 const aiIdentityPattern = /chatgpt|github[ \t-]*copilot|copilot@(github\.com|users\.noreply\.github\.com)|claude[ \t-]+code|noreply@anthropic\.com|gemini([ \t-]+cli)?|codex|noreply@openai\.com|cursor([ \t-]+agent)?|devin[ \t-]+ai|coderabbit|codeium|windsurf|sourcegraph[ \t-]+cody|amazon[ \t-]+q|artificial[ \t-]+intelligence|large[ \t-]+language[ \t-]+model|(^|[^a-z0-9])(ai|llm)[ \t-]+(agent|assistant|bot|tool)([^a-z0-9]|$)/i
 
@@ -35,16 +33,9 @@ async function main() {
 
         let is_success = true
         let autosquash = false
-        let commit_state: RestEndpointMethodTypes["repos"]["createCommitStatus"]["parameters"]["state"] = "success"
+        let failure_message: string | undefined
         let message = "Commit format is correct."
         let files_touched: Array<string> = []
-        let target_url = `https://github.com/${github.context.repo.owner}/${github.context.repo.repo}/blob/HEAD/CONTRIBUTING.md`
-        if (check_package_commit_format) {
-            target_url = "https://docs.brew.sh/Formula-Cookbook#commit"
-        }
-        if (github.context.repo.repo === "homebrew-cask") {
-            target_url = "https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#style-guide"
-        }
 
         // For each commit...
         for (const commit of commits.data) {
@@ -64,8 +55,8 @@ async function main() {
 
             if (aiIdentityPattern.test(identities)) {
                 is_success = false
-                commit_state = "failure"
                 message = "AI author or committer attribution is not allowed."
+                failure_message ??= message
                 break
             }
 
@@ -79,15 +70,15 @@ async function main() {
             if (trailer_start > 0 && message_lines[trailer_start - 1].trim() === "" &&
                 aiIdentityPattern.test(message_lines.slice(trailer_start).join("\n"))) {
                 is_success = false
-                commit_state = "failure"
                 message = "AI commit trailer attribution is not allowed."
+                failure_message ??= message
                 break
             }
 
             if (conventionalCommitPattern.test(commit_message.split("\n")[0])) {
                 is_success = false
-                commit_state = "failure"
                 message = "Conventional commit prefixes are not allowed."
+                failure_message ??= message
                 break
             }
 
@@ -98,16 +89,16 @@ async function main() {
             // Autosquash doesn't support merge commits.
             if (commit_info.data.parents.length != 1) {
                 is_success = false
-                commit_state = "failure"
                 message = `${short_sha} has ${commit_info.data.parents.length} parents. Please rebase against origin/HEAD.`
+                failure_message ??= message
                 break
             }
 
             // Empty commits that are not merge commits are usually a mistake or a bad rebase.
             if (!commit_info.data.files || commit_info.data.files.length === 0) {
                 is_success = false
-                commit_state = "failure"
                 message = `${short_sha} is an empty commit.`
+                failure_message ??= message
                 break
             }
 
@@ -126,8 +117,8 @@ async function main() {
                 }
 
                 if (number_of_formulae_touched > 1) {
-                    commit_state = "failure"
                     message = `${short_sha} modifies ${number_of_formulae_touched} formulae. Please split your commits according to Homebrew style.`
+                    failure_message ??= message
                 } else if (non_formula_modified) {
                     message = `${short_sha} modifies non-formula files (maintainers must merge manually)`
                 }
@@ -145,13 +136,12 @@ async function main() {
                 // We've already modified this file, or the commit subject doesn't start with the formula name.
                 if (files_touched.includes(file.filename) || !commit_subject.startsWith(formula)) {
                     autosquash = true
-                    commit_state = "failure"
                     message = "Please follow the commit style guidelines, or this pull request will be replaced."
+                    failure_message ??= message
                 }
                 files_touched.push(file.filename)
             } else if (file.filename.startsWith("Casks/")) {
                 message = "Commit modifies cask."
-                target_url = "https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#style-guide"
 
                 if (!files_touched.includes(file.filename)) {
                     files_touched.push(file.filename)
@@ -160,6 +150,7 @@ async function main() {
                 if (files_touched.length > 1) {
                     is_success = false
                     message = "A pull request must not modify multiple casks."
+                    failure_message ??= message
                 }
             } else {
                 // Autosquash isn't great at modifying commits that don't modify formulae or casks.
@@ -169,19 +160,8 @@ async function main() {
             }
         }
 
-        const head_sha = commits.data[commits.data.length - 1].sha
-        core.debug(`Writing to sha ${head_sha}`)
-
-        await client.rest.repos.createCommitStatus({
-            ...github.context.repo,
-            sha: head_sha,
-            state: commit_state,
-            description: message,
-            context: "Commit style",
-            target_url: target_url
-        })
-
         if (!check_package_commit_format) {
+            if (failure_message) core.setFailed(failure_message)
             return
         }
 
@@ -223,17 +203,21 @@ async function main() {
             updatedLabels.push(autosquash_label);
         }
 
-        // If everything is the same, we're done
-        if (existingLabels.length == updatedLabels.length && existingLabels.every((label, i) => label == updatedLabels[i])) {
-            return
+        // Update PR labels if they changed
+        if (existingLabels.length != updatedLabels.length || !existingLabels.every((label, i) => label == updatedLabels[i])) {
+            try {
+                await client.rest.issues.update({
+                    ...github.context.repo,
+                    issue_number: pull.number,
+                    labels: updatedLabels
+                })
+            } catch (error) {
+                if (!failure_message || !Error.isError(error)) throw error
+                core.warning(error)
+            }
         }
 
-        // Update PR labels
-        await client.rest.issues.update({
-            ...github.context.repo,
-            issue_number: pull.number,
-            labels: updatedLabels
-        })
+        if (failure_message) core.setFailed(failure_message)
     } catch (error) {
         if (!Error.isError(error)) throw error
 

--- a/check-commit-format/main.test.mts
+++ b/check-commit-format/main.test.mts
@@ -68,25 +68,9 @@ describe("check-commit-format", async () => {
           message: "foo: some commit",
         }
       })
-
-      mockPool.intercept({
-        method: "POST",
-        path: `/repos/${GITHUB_REPOSITORY}/statuses/${sha}`,
-        headers: {
-          Authorization: `token ${token}`,
-        },
-        body: (body) => util.isDeepStrictEqual(JSON.parse(body), {
-          state:       "success",
-          description: "Commit format is correct.",
-          context:     "Commit style",
-          target_url:  "https://docs.brew.sh/Formula-Cookbook#commit"
-        }),
-      }).defaultReplyHeaders({
-        "Content-Type": "application/json",
-      }).reply(200, {})
     })
 
-    it("succeeds without updating labels", async () => {
+    it("succeeds without updating labels or creating a commit status", async () => {
       const mockPool = githubMockPool()
 
       mockPool.intercept({
@@ -172,22 +156,6 @@ describe("check-commit-format", async () => {
           message: "Merge commit",
         }
       })
-
-      mockPool.intercept({
-        method: "POST",
-        path: `/repos/${GITHUB_REPOSITORY}/statuses/${sha}`,
-        headers: {
-          Authorization: `token ${token}`,
-        },
-        body: (body) => util.isDeepStrictEqual(JSON.parse(body), {
-          state:       "failure",
-          description: `${sha.substring(0, 10)} has 2 parents. Please rebase against origin/HEAD.`,
-          context:     "Commit style",
-          target_url:  "https://docs.brew.sh/Formula-Cookbook#commit"
-        }),
-      }).defaultReplyHeaders({
-        "Content-Type": "application/json",
-      }).reply(200, {})
     })
 
     it("fails and adds a failure label", async () => {
@@ -218,8 +186,48 @@ describe("check-commit-format", async () => {
         "Content-Type": "application/json",
       }).reply(200, {})
 
-      await loadMain()
+      await assert.rejects(
+        loadMain(),
+        new Error(`${sha.substring(0, 10)} has 2 parents. Please rebase against origin/HEAD.`),
+      )
     })
+
+    it("preserves the validation failure when adding its label fails", async () => {
+      const mockPool = githubMockPool()
+
+      mockPool.intercept({
+        method: "GET",
+        path: `/repos/${GITHUB_REPOSITORY}/issues/${pr}/labels`,
+        headers: {
+          Authorization: `token ${token}`,
+        },
+      }).defaultReplyHeaders({
+        "Content-Type": "application/json",
+      }).reply(200, [
+        { name: "other-label" },
+      ])
+
+      mockPool.intercept({
+        method: "PATCH",
+        path: `/repos/${GITHUB_REPOSITORY}/issues/${pr}`,
+        headers: {
+          Authorization: `token ${token}`,
+        },
+        body: (body) => util.isDeepStrictEqual(JSON.parse(body), {
+          labels: ["other-label", failureLabel],
+        }),
+      }).defaultReplyHeaders({
+        "Content-Type": "application/json",
+      }).reply(403, {
+        message: "Resource not accessible by integration",
+      })
+
+      await assert.rejects(
+        loadMain(),
+        new Error(`${sha.substring(0, 10)} has 2 parents. Please rebase against origin/HEAD.`),
+      )
+    })
+
   })
 
   describe("on an empty commit", async () => {
@@ -256,22 +264,6 @@ describe("check-commit-format", async () => {
           message: "Empty commit",
         }
       })
-
-      mockPool.intercept({
-        method: "POST",
-        path: `/repos/${GITHUB_REPOSITORY}/statuses/${sha}`,
-        headers: {
-          Authorization: `token ${token}`,
-        },
-        body: (body) => util.isDeepStrictEqual(JSON.parse(body), {
-          state:       "failure",
-          description: `${sha.substring(0, 10)} is an empty commit.`,
-          context:     "Commit style",
-          target_url:  "https://docs.brew.sh/Formula-Cookbook#commit"
-        }),
-      }).defaultReplyHeaders({
-        "Content-Type": "application/json",
-      }).reply(200, {})
     })
 
     it("fails and adds a failure label", async () => {
@@ -302,7 +294,10 @@ describe("check-commit-format", async () => {
         "Content-Type": "application/json",
       }).reply(200, {})
 
-      await loadMain()
+      await assert.rejects(
+        loadMain(),
+        new Error(`${sha.substring(0, 10)} is an empty commit.`),
+      )
     })
   })
 
@@ -340,22 +335,6 @@ describe("check-commit-format", async () => {
           message: "Update foo.rb",
         }
       })
-
-      mockPool.intercept({
-        method: "POST",
-        path: `/repos/${GITHUB_REPOSITORY}/statuses/${sha}`,
-        headers: {
-          Authorization: `token ${token}`,
-        },
-        body: (body) => util.isDeepStrictEqual(JSON.parse(body), {
-          state:       "failure",
-          description: "Please follow the commit style guidelines, or this pull request will be replaced.",
-          context:     "Commit style",
-          target_url:  "https://docs.brew.sh/Formula-Cookbook#commit"
-        }),
-      }).defaultReplyHeaders({
-        "Content-Type": "application/json",
-      }).reply(200, {})
     })
 
     it("fails and adds a autosquash label", async () => {
@@ -386,7 +365,10 @@ describe("check-commit-format", async () => {
         "Content-Type": "application/json",
       }).reply(200, {})
 
-      await loadMain()
+      await assert.rejects(
+        loadMain(),
+        new Error("Please follow the commit style guidelines, or this pull request will be replaced."),
+      )
     })
 
     it("fails while retaining existing autosquash labels", async () => {
@@ -404,7 +386,96 @@ describe("check-commit-format", async () => {
         { name: autosquashLabel },
       ])
 
-      await loadMain()
+      await assert.rejects(
+        loadMain(),
+        new Error("Please follow the commit style guidelines, or this pull request will be replaced."),
+      )
+    })
+  })
+
+  describe("on multiple package commits", () => {
+    function mockCommits(commits: Array<{ sha: string, filename: string, message: string }>) {
+      const mockPool = githubMockPool()
+
+      mockPool.intercept({
+        method: "GET",
+        path: `/repos/${GITHUB_REPOSITORY}/pulls/${pr}/commits`,
+        headers: {
+          Authorization: `token ${token}`,
+        },
+      }).defaultReplyHeaders({
+        "Content-Type": "application/json",
+      }).reply(200, commits.map(commit => ({ sha: commit.sha })))
+
+      for (const commit of commits) {
+        mockPool.intercept({
+          method: "GET",
+          path: `/repos/${GITHUB_REPOSITORY}/commits/${commit.sha}`,
+          headers: {
+            Authorization: `token ${token}`,
+          },
+        }).defaultReplyHeaders({
+          "Content-Type": "application/json",
+        }).reply(200, {
+          sha: commit.sha,
+          parents: [{ sha: "abcdef1234567890abcdef1234567890abcdef11" }],
+          files: [{ filename: commit.filename }],
+          commit: {
+            message: commit.message,
+          }
+        })
+      }
+    }
+
+    function mockLabelUpdate(labels: Array<string>) {
+      const mockPool = githubMockPool()
+
+      mockPool.intercept({
+        method: "GET",
+        path: `/repos/${GITHUB_REPOSITORY}/issues/${pr}/labels`,
+        headers: {
+          Authorization: `token ${token}`,
+        },
+      }).defaultReplyHeaders({
+        "Content-Type": "application/json",
+      }).reply(200, [])
+
+      mockPool.intercept({
+        method: "PATCH",
+        path: `/repos/${GITHUB_REPOSITORY}/issues/${pr}`,
+        headers: {
+          Authorization: `token ${token}`,
+        },
+        body: (body) => util.isDeepStrictEqual(JSON.parse(body), { labels }),
+      }).defaultReplyHeaders({
+        "Content-Type": "application/json",
+      }).reply(200, {})
+    }
+
+    it("preserves the first validation failure message", async () => {
+      mockCommits([
+        { sha: `${sha.slice(0, -1)}1`, filename: "Formula/foo.rb", message: "Update foo.rb" },
+        { sha: sha, filename: "Casks/bar.rb", message: "bar: update" },
+      ])
+      mockLabelUpdate([failureLabel, autosquashLabel])
+
+      await assert.rejects(
+        loadMain(),
+        new Error("Please follow the commit style guidelines, or this pull request will be replaced."),
+      )
+    })
+
+    it("fails when multiple casks are modified", async () => {
+      mockCommits([
+        { sha: `${sha.slice(0, -1)}1`, filename: "Casks/foo.rb", message: "foo: update" },
+        { sha: sha, filename: "Casks/bar.rb", message: "bar: update" },
+      ])
+      mockLabelUpdate([failureLabel])
+
+      await assert.rejects(
+        loadMain(),
+        new Error("A pull request must not modify multiple casks."),
+      )
     })
   })
 
@@ -416,8 +487,7 @@ describe("check-commit-format", async () => {
       author: Identity,
       committer: Identity,
       files: Array<{ filename: string }>,
-      state: "success" | "failure",
-      description: string,
+      failure?: string,
     ) {
       const repository = "Homebrew/brew"
       process.env.GITHUB_REPOSITORY = repository
@@ -453,23 +523,11 @@ describe("check-commit-format", async () => {
         },
       })
 
-      mockPool.intercept({
-        method: "POST",
-        path: `/repos/${repository}/statuses/${sha}`,
-        headers: {
-          Authorization: `token ${token}`,
-        },
-        body: (body) => util.isDeepStrictEqual(JSON.parse(body), {
-          state:       state,
-          description: description,
-          context:     "Commit style",
-          target_url:  "https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md",
-        }),
-      }).defaultReplyHeaders({
-        "Content-Type": "application/json",
-      }).reply(200, {})
-
-      await loadMain()
+      if (failure) {
+        await assert.rejects(loadMain(), new Error(failure))
+      } else {
+        await loadMain()
+      }
     }
 
     const contributor = { name: "Homebrew Contributor", email: "contributor@example.com" }
@@ -539,7 +597,6 @@ describe("check-commit-format", async () => {
           commit.author,
           commit.committer,
           [{ filename: "README.md" }],
-          "failure",
           commit.description,
         )
       })
@@ -551,8 +608,6 @@ describe("check-commit-format", async () => {
         { name: "Claude Dupont", email: "claude@example.com" },
         contributor,
         [{ filename: "README.md" }, { filename: "docs/FAQ.md" }],
-        "success",
-        "Commit format is correct.",
       )
     })
   })


### PR DESCRIPTION
- Fail validation through the workflow for read-only fork tokens.
- Preserve existing package-repository label management.
- Document Issues permissions and branch protection migration.