### PR TITLE
setup-homebrew: remove Bubblewrap logic

### DIFF
--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -31,16 +31,18 @@ jobs:
           - os: ubuntu-latest
             key: docker-root
             stable: false
-            container: '{"image": "ghcr.io/homebrew/brew:main", "options": "--user=root --privileged"}'
+            container: '{"image": "ghcr.io/homebrew/brew:main", "options": "--user=root"}'
             name: Docker (root)
           - os: ubuntu-latest
             key: docker-linuxbrew
             stable: false
-            container: '{"image": "ghcr.io/homebrew/brew:main", "options": "--user=linuxbrew --privileged"}'
+            container: '{"image": "ghcr.io/homebrew/brew:main", "options": "--user=linuxbrew"}'
             name: Docker (linuxbrew)
           - os: ubuntu-latest
             key: docker-linuxbrew-stable
             stable: true
+            # Stable `brew` still sandboxes with Bubblewrap, which needs
+            # `--privileged` for its user namespaces.
             container: '{"image": "ghcr.io/homebrew/brew:latest", "options": "--user=linuxbrew --privileged"}'
             name: Docker (stable)
     runs-on: ${{ matrix.os }}
@@ -90,12 +92,6 @@ jobs:
         run: brew install-bundler-gems
 
       - run: brew test-bot --only-cleanup-before
-
-      - name: Install bubblewrap
-        if: matrix.os == 'ubuntu-24.04'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends bubblewrap
 
       - name: Disable Linux sandbox when unsupported
         if: matrix.key == 'ubuntu-slim'

--- a/setup-homebrew/action.yml
+++ b/setup-homebrew/action.yml
@@ -17,10 +17,6 @@ inputs:
     description: Show debugging output
     required: false
     default: ${{ runner.debug == '1' }}
-  setup-sandbox:
-    description: Setup sandboxes (if needed). Currently no-op on non-Linux.
-    required: false
-    default: false
   token:
     description: Token to be used for GitHub authentication (if using private repositories). This token will persist through other steps for the duration of the job.
     required: false

--- a/setup-homebrew/main.mts
+++ b/setup-homebrew/main.mts
@@ -13,7 +13,6 @@ try {
     core.getInput("token"),
     core.getInput("stable"),
     core.getInput("brew-gh-api-token"),
-    core.getInput("setup-sandbox"),
   ])
 } catch (error) {
   if (!Error.isError(error)) throw error

--- a/setup-homebrew/main.sh
+++ b/setup-homebrew/main.sh
@@ -8,7 +8,6 @@ DEBUG="${3}"
 TOKEN="${4}"
 STABLE="${5}"
 BREW_GH_API_TOKEN="${6}"
-SETUP_SANDBOX="${7}"
 
 if [[ "${DEBUG}" == "true" ]]; then
     set -x
@@ -333,12 +332,6 @@ fi
 
 # Setup Linux permissions
 if [[ "$RUNNER_OS" = "Linux" ]] && [[ -z "${HOMEBREW_IN_CONTAINER-}" ]] && [[ -z "${GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-}" ]]; then
-    if [[ "${SETUP_SANDBOX}" == "true" ]]; then
-        # Install Bubblewrap and configure the sandbox sysctls. Pass GITHUB_ACTIONS
-        # through `sudo` so `brew setup-sandbox` installs Bubblewrap when missing.
-        sudo GITHUB_ACTIONS="${GITHUB_ACTIONS-}" "${HOMEBREW_PREFIX}/bin/brew" setup-sandbox
-    fi
-
     # Workaround: Remove fontconfig incompatible fonts provided by the poppler
     # installation in GitHub Actions image
     sudo rm -rf /usr/share/fonts/cmap


### PR DESCRIPTION
- Homebrew's Linux sandbox has moved to Landlock, which needs no helper binary, kernel sysctls or `--privileged` containers.
- Remove the `setup-sandbox` input whose only job was installing and configuring Bubblewrap via `brew setup-sandbox`.
- Rely on Landlock as the default implementation instead of setting `HOMEBREW_SANDBOX_LINUX_LANDLOCK` in CI.

Needs https://github.com/Homebrew/brew/pull/23425