### PR TITLE
setup-homebrew: unprivileged stable Docker container

### DIFF
--- a/.github/workflows/setup-homebrew.yml
+++ b/.github/workflows/setup-homebrew.yml
@@ -41,9 +41,7 @@ jobs:
           - os: ubuntu-latest
             key: docker-linuxbrew-stable
             stable: true
-            # Stable `brew` still sandboxes with Bubblewrap, which needs
-            # `--privileged` for its user namespaces.
-            container: '{"image": "ghcr.io/homebrew/brew:latest", "options": "--user=linuxbrew --privileged"}'
+            container: '{"image": "ghcr.io/homebrew/brew:latest", "options": "--user=linuxbrew"}'
             name: Docker (stable)
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container && fromJSON(matrix.container) || '' }}


### PR DESCRIPTION
Stable `brew` sandboxes with Landlock now, so the container no longer needs `--privileged` for Bubblewrap's user namespaces.

Needs a stable release containing https://github.com/Homebrew/brew/pull/23425