### PR TITLE
check-commit-format: allow multiple casks

### DIFF
--- a/check-commit-format/main.mts
+++ b/check-commit-format/main.mts
@@ -140,19 +140,7 @@ async function main() {
                     failure_message ??= message
                 }
                 files_touched.push(file.filename)
-            } else if (file.filename.startsWith("Casks/")) {
-                message = "Commit modifies cask."
-
-                if (!files_touched.includes(file.filename)) {
-                    files_touched.push(file.filename)
-                }
-
-                if (files_touched.length > 1) {
-                    is_success = false
-                    message = "A pull request must not modify multiple casks."
-                    failure_message ??= message
-                }
-            } else {
+            } else if (!file.filename.startsWith("Casks/")) {
                 // Autosquash isn't great at modifying commits that don't modify formulae or casks.
                 is_success = false
                 message = `${short_sha} modifies non-formulae or non-cask files (maintainers must merge manually)`

--- a/check-commit-format/main.test.mts
+++ b/check-commit-format/main.test.mts
@@ -455,26 +455,13 @@ describe("check-commit-format", async () => {
     it("preserves the first validation failure message", async () => {
       mockCommits([
         { sha: `${sha.slice(0, -1)}1`, filename: "Formula/foo.rb", message: "Update foo.rb" },
-        { sha: sha, filename: "Casks/bar.rb", message: "bar: update" },
+        { sha: sha, filename: "docs/foo.md", message: "Update docs" },
       ])
       mockLabelUpdate([failureLabel, autosquashLabel])
 
       await assert.rejects(
         loadMain(),
         new Error("Please follow the commit style guidelines, or this pull request will be replaced."),
-      )
-    })
-
-    it("fails when multiple casks are modified", async () => {
-      mockCommits([
-        { sha: `${sha.slice(0, -1)}1`, filename: "Casks/foo.rb", message: "foo: update" },
-        { sha: sha, filename: "Casks/bar.rb", message: "bar: update" },
-      ])
-      mockLabelUpdate([failureLabel])
-
-      await assert.rejects(
-        loadMain(),
-        new Error("A pull request must not modify multiple casks."),
       )
     })
   })


### PR DESCRIPTION
Multi-cask pull requests are common and should not fail commit format validation or receive automerge-skip.

The removed check counted formula files too, so it also flagged mixed formula and cask pull requests, depending on commit order.