### PR TITLE
workflows: vendor Dependabot npm updates automatically

### DIFF
--- a/.github/scripts/test_vendor_node_modules.py
+++ b/.github/scripts/test_vendor_node_modules.py
@@ -1,0 +1,373 @@
+import copy
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import vendor_node_modules as vendor
+
+
+REPOSITORY = "Homebrew/actions"
+BRANCH = "dependabot/npm_and_yarn/npm-test"
+
+
+def pull_request(head="a" * 40):
+    return {
+        "number": 12, "state": "open", "changed_files": 1,
+        "user": {"login": "dependabot[bot]"},
+        "head": {"sha": head, "ref": BRANCH, "repo": {"full_name": REPOSITORY}},
+        "base": {"ref": "main", "repo": {"full_name": REPOSITORY}},
+    }
+
+
+class SelectionTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        directory = Path(self.temporary.name)
+        self.event_path = directory / "event.json"
+        self.outputs = directory / "outputs"
+        self.env = patch.dict(os.environ, {
+            "GITHUB_EVENT_PATH": str(self.event_path), "GITHUB_OUTPUT": str(self.outputs),
+            "GITHUB_EVENT_NAME": "workflow_run", "GITHUB_REPOSITORY": REPOSITORY,
+        })
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.event = {
+            "repository": {"default_branch": "main"},
+            "workflow_run": {
+                "event": "pull_request", "path": ".github/workflows/test.yml",
+                "conclusion": "failure", "head_sha": "a" * 40,
+                "head_repository": {"full_name": REPOSITORY}, "pull_requests": [],
+            },
+        }
+        self.pr = pull_request()
+        self.files = [{"filename": "package-lock.json"}]
+
+    def select(self):
+        self.event_path.write_text(json.dumps(self.event))
+
+        def api(path, paginate=False):
+            if "/commits/" in path:
+                return [{"number": 12}]
+            if path.endswith("/files"):
+                return self.files
+            return self.pr
+
+        with patch.object(vendor, "api", side_effect=api), patch.object(vendor, "git", return_value=b"b" * 40):
+            vendor.select()
+        return self.outputs.read_text()
+
+    def test_selects_failed_node_test_with_empty_event_pr_list(self):
+        self.assertIn("selected=true", self.select())
+
+    def test_selects_successful_node_test(self):
+        self.event["workflow_run"]["conclusion"] = "success"
+        self.assertIn("selected=true", self.select())
+
+    def test_skips_outdated_run(self):
+        self.pr["head"]["sha"] = "c" * 40
+        self.assertIn("selected=false", self.select())
+
+    def test_skips_closed_pr(self):
+        self.pr["state"] = "closed"
+        self.assertIn("selected=false", self.select())
+
+    def test_skips_fork(self):
+        self.pr["head"]["repo"]["full_name"] = "example/actions"
+        self.assertIn("selected=false", self.select())
+
+    def test_skips_human_authored_pr(self):
+        self.pr["user"]["login"] = "example"
+        self.assertIn("selected=false", self.select())
+
+    def test_skips_non_npm_dependabot_pr(self):
+        self.pr["head"]["ref"] = "dependabot/github_actions/actions-group"
+        self.assertIn("selected=false", self.select())
+
+    def test_skips_pr_without_manifest_changes(self):
+        self.files = [{"filename": "README.md"}]
+        self.assertIn("selected=false", self.select())
+
+    def test_rejects_incomplete_file_listing(self):
+        self.pr["changed_files"] = 2
+        with self.assertRaisesRegex(ValueError, "Incomplete"):
+            self.select()
+
+    def test_skips_push_and_cancelled_runs(self):
+        for key, value in (("event", "push"), ("conclusion", "cancelled"), ("path", ".github/workflows/other.yml")):
+            with self.subTest(key=key):
+                original = self.event["workflow_run"][key]
+                self.event["workflow_run"][key] = value
+                self.assertIn("selected=false", self.select())
+                self.event["workflow_run"][key] = original
+
+    def test_manual_dispatch_allows_same_repository_human_pr(self):
+        os.environ["GITHUB_EVENT_NAME"] = "workflow_dispatch"
+        self.event["inputs"] = {"pull_request": "12"}
+        self.pr["user"]["login"] = "example"
+        self.pr["head"]["ref"] = "maintenance"
+        self.assertIn("selected=true", self.select())
+
+
+class LockTests(unittest.TestCase):
+    def setUp(self):
+        self.manifest = {"dependencies": {"example": "^1.0.0"}}
+        self.package = {
+            "version": "1.0.0", "resolved": "https://registry.npmjs.org/example/-/example-1.0.0.tgz",
+            "integrity": "sha512-" + "a" * 86 + "==",
+        }
+        self.lock = {"lockfileVersion": 3, "packages": {"": self.manifest, "node_modules/example": self.package}}
+
+    def test_accepts_registry_lock(self):
+        vendor.validate_lock(self.manifest, self.lock)
+
+    def bundled_lock(self):
+        lock = copy.deepcopy(self.lock)
+        lock["packages"]["node_modules/example"]["bundleDependencies"] = ["@scope/bundled"]
+        lock["packages"]["node_modules/example/node_modules/@scope/bundled"] = {
+            "version": "1.0.0", "inBundle": True,
+        }
+        return lock
+
+    def test_accepts_packages_inside_a_pinned_bundle(self):
+        vendor.validate_lock(self.manifest, self.bundled_lock())
+
+    def test_accepts_nested_bundled_dependencies(self):
+        lock = self.bundled_lock()
+        lock["packages"]["node_modules/example/node_modules/@scope/bundled/node_modules/nested"] = {
+            "version": "1.0.0", "inBundle": True,
+        }
+        vendor.validate_lock(self.manifest, lock)
+
+    def test_bundle_requires_a_containing_bundler(self):
+        for parent in (None, {}, {"bundleDependencies": []}):
+            with self.subTest(parent=parent):
+                lock = self.bundled_lock()
+                if parent is None:
+                    del lock["packages"]["node_modules/example"]
+                else:
+                    lock["packages"]["node_modules/example"] = {**self.package, **parent}
+                with self.assertRaises(ValueError):
+                    vendor.validate_lock(self.manifest, lock)
+        lock = self.bundled_lock()
+        lock["packages"]["node_modules/example"] = {"version": "1.0.0", "inBundle": True}
+        with self.assertRaises(ValueError):
+            vendor.validate_lock(self.manifest, lock)
+
+    def test_bundle_parent_still_requires_registry_integrity(self):
+        for changes in ({"resolved": "https://example.com/package.tgz"}, {"integrity": ""}):
+            with self.subTest(changes=changes):
+                lock = self.bundled_lock()
+                lock["packages"]["node_modules/example"].update(changes)
+                with self.assertRaises(ValueError):
+                    vendor.validate_lock(self.manifest, lock)
+
+    def test_bundled_entries_keep_path_link_and_explicit_source_checks(self):
+        for changes in ({"link": True}, {"resolved": "https://example.com/package.tgz"}, {"inBundle": False}):
+            with self.subTest(changes=changes):
+                lock = self.bundled_lock()
+                lock["packages"]["node_modules/example/node_modules/@scope/bundled"].update(changes)
+                with self.assertRaises(ValueError):
+                    vendor.validate_lock(self.manifest, lock)
+        lock = self.bundled_lock()
+        lock["packages"]["other/bundled"] = {"version": "1.0.0", "inBundle": True}
+        with self.assertRaises(ValueError):
+            vendor.validate_lock(self.manifest, lock)
+
+    def test_rejects_other_sources_or_missing_integrity(self):
+        for changes in ({"resolved": "https://example.com/package.tgz"}, {"integrity": ""}, {"link": True}):
+            with self.subTest(changes=changes):
+                lock = copy.deepcopy(self.lock)
+                lock["packages"]["node_modules/example"].update(changes)
+                with self.assertRaises(ValueError):
+                    vendor.validate_lock(self.manifest, lock)
+
+    def test_rejects_local_dependency_and_workspaces(self):
+        for manifest in ({"dependencies": {"example": "file:./example"}}, {"workspaces": ["packages/*"]}):
+            with self.subTest(manifest=manifest), self.assertRaises(ValueError):
+                vendor.validate_lock(manifest, self.lock)
+
+    def test_rejects_noncanonical_package_paths(self):
+        for path in ("other/example", "node_modules//example", "node_modules/./example"):
+            with self.subTest(path=path):
+                lock = {"lockfileVersion": 3, "packages": {"": self.manifest, path: self.package}}
+                with self.assertRaises(ValueError):
+                    vendor.validate_lock(self.manifest, lock)
+
+
+class GitTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        seed = self.root / "seed"
+        seed.mkdir()
+        self.repository = seed
+        self.git("init", "--quiet", "--initial-branch=main")
+        self.configure()
+        (seed / "automation.txt").write_text("trusted checkout\n")
+        (seed / ".gitignore").write_text("/node_modules/.bin/\n")
+        (seed / ".npmrc").write_text("lockfile-version=3\n")
+        (seed / "package.json").write_text('{"name":"fixture"}\n')
+        (seed / "package-lock.json").write_text('{"name":"fixture","lockfileVersion":3,"packages":{"":{}}}\n')
+        (seed / "node_modules/example").mkdir(parents=True)
+        (seed / "node_modules/example/index.js").write_text("original\n")
+        self.git("add", ".")
+        self.git("commit", "--quiet", "-m", "trusted fixture")
+        self.git("checkout", "--quiet", "-b", BRANCH)
+        (seed / "automation.txt").write_text("pull request content\n")
+        self.git("commit", "--quiet", "--all", "-m", "pull request fixture")
+        self.head = self.git("rev-parse", "HEAD").decode().strip()
+        self.git("checkout", "--quiet", "main")
+        self.remote = self.root / "remote.git"
+        self.git("clone", "--quiet", "--bare", str(seed), str(self.remote))
+        self.repository = self.root / "trusted"
+        subprocess.run(["git", "clone", "--quiet", str(self.remote), str(self.repository)], check=True)
+        self.configure()
+        self.pr = pull_request(self.head)
+        self.outputs = self.root / "outputs"
+        self.patch_file = self.root / "vendor.patch"
+        self.tools = self.root / "bin"
+        self.tools.mkdir()
+        npm = self.tools / "npm"
+        npm.write_text('''#!/bin/sh
+set -eu
+[ "$*" = "ci --ignore-scripts --omit=dev --no-audit --no-fund" ] || exit 99
+mkdir -p node_modules/example node_modules/.bin
+printf 'updated\\n' > node_modules/example/index.js
+printf 'new dependency\\n' > node_modules/example/new.js
+touch node_modules/.bin/example
+''')
+        npm.chmod(0o755)
+        env = patch.dict(os.environ, {
+            "GITHUB_OUTPUT": str(self.outputs), "GITHUB_REPOSITORY": REPOSITORY,
+            "PR_HEAD": self.head, "PR_BRANCH": BRANCH, "PR_NUMBER": "12", "DEFAULT_BRANCH": "main",
+            "PATH": f"{self.tools}{os.pathsep}{os.environ['PATH']}", "GH_TOKEN": "fixture-token",
+        })
+        env.start()
+        self.addCleanup(env.stop)
+        previous = Path.cwd()
+        os.chdir(self.repository)
+        self.addCleanup(os.chdir, previous)
+
+    def git(self, *args, **kwargs):
+        return subprocess.run(["git", *args], cwd=self.repository, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, **kwargs).stdout
+
+    def configure(self):
+        for key, value in (("user.name", "Vendor Test"), ("user.email", "test@example.com"), ("commit.gpgsign", "false")):
+            self.git("config", key, value)
+
+    def prepare(self):
+        vendor.generate(self.patch_file)
+        with patch.object(vendor, "api", return_value=self.pr):
+            vendor.prepare(self.patch_file)
+        return dict(line.split("=", 1) for line in self.outputs.read_text().splitlines())["tree"]
+
+    def signing(self):
+        key = self.root / "signing-key"
+        subprocess.run(["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-C", "fixture", "-f", str(key)], check=True)
+        allowed = self.root / "allowed-signers"
+        allowed.write_text("test@example.com " + key.with_suffix(".pub").read_text())
+        self.git("config", "gpg.format", "ssh")
+        self.git("config", "gpg.ssh.program", "ssh-keygen")
+        self.git("config", "user.signingkey", str(key))
+        self.git("config", "gpg.ssh.allowedSignersFile", str(allowed))
+
+    def test_generation_and_preparation_never_check_out_pr_code(self):
+        tree = self.prepare()
+        self.assertEqual((self.repository / "automation.txt").read_text(), "trusted checkout\n")
+        self.assertEqual(self.git("show", f"{tree}:automation.txt"), b"pull request content\n")
+        self.assertEqual(self.git("show", f"{tree}:node_modules/example/new.js"), b"new dependency\n")
+        self.assertEqual(self.git("status", "--porcelain"), b"")
+        self.assertNotIn(b"node_modules/.bin", self.patch_file.read_bytes())
+
+    def test_generation_detects_new_files_without_tracked_changes(self):
+        npm = self.tools / "npm"
+        npm.write_text(npm.read_text().replace("updated", "original"))
+        vendor.generate(self.patch_file)
+        self.assertIn("changed=true", self.outputs.read_text())
+        self.assertIn(b"new.js", self.patch_file.read_bytes())
+
+    def test_noop_generation_does_not_request_publication(self):
+        (self.tools / "npm").write_text("#!/bin/sh\nmkdir -p node_modules/example\nprintf 'original\\n' > node_modules/example/index.js\n")
+        vendor.generate(self.patch_file)
+        self.assertIn("changed=false", self.outputs.read_text())
+        self.assertEqual(self.patch_file.read_bytes(), b"")
+
+    def test_installer_failure_stops_generation(self):
+        (self.tools / "npm").write_text("#!/bin/sh\nexit 42\n")
+        with self.assertRaises(subprocess.CalledProcessError) as error:
+            vendor.generate(self.patch_file)
+        self.assertEqual(error.exception.returncode, 42)
+        self.assertFalse(self.patch_file.exists())
+
+    def test_stale_pr_is_skipped_before_applying_artifact(self):
+        self.pr["head"]["sha"] = "0" * 40
+        with patch.object(vendor, "api", return_value=self.pr):
+            vendor.prepare(self.root / "does-not-exist")
+        self.assertEqual(self.outputs.read_text(), "changed=false\n")
+
+    def test_publisher_rejects_changes_outside_dependencies(self):
+        (self.repository / "automation.txt").write_text("another version\n")
+        self.patch_file.write_bytes(self.git("diff", self.head, "--", "automation.txt"))
+        self.git("restore", "automation.txt")
+        with patch.object(vendor, "api", return_value=self.pr), self.assertRaisesRegex(ValueError, "only touch node_modules"):
+            vendor.prepare(self.patch_file)
+        self.assertEqual((self.repository / "automation.txt").read_text(), "trusted checkout\n")
+
+    def test_publisher_rejects_symlinks(self):
+        (self.repository / "node_modules/example/link").symlink_to("index.js")
+        self.git("add", "node_modules/example/link")
+        self.patch_file.write_bytes(self.git("diff", "--cached", self.head, "--", "node_modules"))
+        self.git("reset", "--quiet")
+        with patch.object(vendor, "api", return_value=self.pr), self.assertRaisesRegex(ValueError, "regular files"):
+            vendor.prepare(self.patch_file)
+
+    def test_publishes_signed_child_of_selected_head(self):
+        os.environ["VENDOR_TREE"] = self.prepare()
+        self.signing()
+        with patch.object(vendor, "api", return_value=self.pr):
+            vendor.publish()
+        commit = self.git("ls-remote", "origin", f"refs/heads/{BRANCH}").decode().split()[0]
+        self.assertEqual(self.git("rev-parse", f"{commit}^").decode().strip(), self.head)
+        self.assertIn(b"[dependabot skip]", self.git("show", "--no-patch", "--format=%B", commit))
+        self.git("verify-commit", commit)
+        self.assertEqual(self.git("status", "--porcelain"), b"")
+
+    def test_concurrent_branch_update_is_not_overwritten(self):
+        os.environ["VENDOR_TREE"] = self.prepare()
+        self.signing()
+        competing = self.git("commit-tree", "HEAD^{tree}", "-p", self.head, "-m", "concurrent update").decode().strip()
+
+        def api(path):
+            self.git("push", "--quiet", "origin", f"{competing}:refs/heads/{BRANCH}")
+            return self.pr
+
+        with patch.object(vendor, "api", side_effect=api), self.assertRaises(subprocess.CalledProcessError) as error:
+            vendor.publish()
+        self.assertIn("push", error.exception.cmd)
+        remote = self.git("ls-remote", "origin", f"refs/heads/{BRANCH}").decode().split()[0]
+        self.assertEqual(remote, competing)
+
+    def test_concurrent_rewind_is_not_reintroduced(self):
+        os.environ["VENDOR_TREE"] = self.prepare()
+        self.signing()
+        previous = self.git("rev-parse", "HEAD").decode().strip()
+
+        def api(path):
+            self.git("push", "--quiet", "--force", "origin", f"{previous}:refs/heads/{BRANCH}")
+            return self.pr
+
+        with patch.object(vendor, "api", side_effect=api), self.assertRaises(subprocess.CalledProcessError) as error:
+            vendor.publish()
+        self.assertIn("push", error.exception.cmd)
+        remote = self.git("ls-remote", "origin", f"refs/heads/{BRANCH}").decode().split()[0]
+        self.assertEqual(remote, previous)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/vendor_node_modules.py
+++ b/.github/scripts/vendor_node_modules.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Regenerate dependencies without checking out or executing a pull request."""
+
+import base64
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import sys
+import tempfile
+from urllib.parse import urlsplit
+
+
+def run(*args, **kwargs):
+    return subprocess.run(args, check=True, stdout=subprocess.PIPE, **kwargs).stdout
+
+
+def git(*args, **kwargs):
+    return run("git", "-c", "core.hooksPath=/dev/null", *args, **kwargs)
+
+
+def api(path, paginate=False):
+    args = ["gh", "api", path]
+    if paginate:
+        args += ["--paginate", "--slurp"]
+    result = json.loads(run(*args))
+    return [item for page in result for item in page] if paginate else result
+
+
+def output(name, value):
+    value = str(value)
+    if "\n" in value or "\r" in value:
+        raise ValueError("Invalid workflow output")
+    with open(os.environ["GITHUB_OUTPUT"], "a") as stream:
+        stream.write(f"{name}={value}\n")
+
+
+def sha(value):
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{40}", value):
+        raise ValueError("Invalid commit or tree SHA")
+    return value
+
+
+def eligible(pr, repository, default_branch, head=None, automatic=False):
+    return (
+        pr["state"] == "open"
+        and pr["head"]["repo"] is not None
+        and pr["head"]["repo"]["full_name"] == repository
+        and pr["base"]["repo"]["full_name"] == repository
+        and pr["base"]["ref"] == default_branch
+        and (head is None or pr["head"]["sha"] == head)
+        and (not automatic or (
+            pr["user"]["login"] == "dependabot[bot]"
+            and pr["head"]["ref"].startswith("dependabot/npm_and_yarn/")
+        ))
+    )
+
+
+def select():
+    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    repository = os.environ["GITHUB_REPOSITORY"]
+    default_branch = event["repository"]["default_branch"]
+    if os.environ["GITHUB_EVENT_NAME"] == "workflow_dispatch":
+        number = event["inputs"]["pull_request"]
+        if not re.fullmatch(r"[1-9][0-9]*", str(number)):
+            raise ValueError("A pull request number is required")
+        pr = api(f"repos/{repository}/pulls/{number}")
+        candidates = [pr] if eligible(pr, repository, default_branch) else []
+    else:
+        workflow = event["workflow_run"]
+        if (workflow["event"] != "pull_request"
+                or workflow["path"] != ".github/workflows/test.yml"
+                or workflow["conclusion"] not in ("success", "failure")
+                or workflow["head_repository"]["full_name"] != repository):
+            output("selected", "false")
+            return
+        head = sha(workflow["head_sha"])
+        candidates = []
+        for associated in api(f"repos/{repository}/commits/{head}/pulls", paginate=True):
+            pr = api(f"repos/{repository}/pulls/{associated['number']}")
+            if eligible(pr, repository, default_branch, head, automatic=True):
+                files = api(f"repos/{repository}/pulls/{pr['number']}/files", paginate=True)
+                if len(files) != pr["changed_files"]:
+                    raise ValueError("Incomplete pull request file list")
+                if any(f["filename"] in ("package.json", "package-lock.json") for f in files):
+                    candidates.append(pr)
+    if not candidates:
+        print("No current eligible pull request; skipping.")
+        output("selected", "false")
+        return
+    if len(candidates) != 1:
+        raise ValueError("Expected one eligible pull request")
+    pr = candidates[0]
+    git("check-ref-format", f"refs/heads/{pr['head']['ref']}")
+    output("pull_request", pr["number"])
+    output("head", sha(pr["head"]["sha"]))
+    output("branch", pr["head"]["ref"])
+    output("selected", "true")
+
+
+def vendor_path(path):
+    parts = PurePosixPath(path).parts
+    return (
+        path.startswith("node_modules/")
+        and str(PurePosixPath(path)) == path
+        and "\\" not in path
+        and not any(p.lower() in ("..", ".git") for p in parts)
+    )
+
+
+def validate_lock(manifest, lock):
+    if manifest.get("workspaces") or lock.get("lockfileVersion") != 3:
+        raise ValueError("Expected a standalone npm v3 lockfile")
+    for section in ("dependencies", "devDependencies", "optionalDependencies"):
+        for version in manifest.get(section, {}).values():
+            if not re.fullmatch(r"[~^<>=*0-9v][0-9A-Za-z.+*~^<>=| -]*", version):
+                raise ValueError("Automatic vendoring requires registry version ranges")
+    packages = lock["packages"]
+    if "" not in packages:
+        raise ValueError("Missing root package in lockfile")
+    for path, package in packages.items():
+        if not path:
+            continue
+        if not vendor_path(path) or package.get("link"):
+            raise ValueError("Dependencies must be regular packages inside node_modules")
+        if package.get("inBundle") is True and "resolved" not in package and "integrity" not in package:
+            # Bundled files inherit the containing tarball's integrity. Its
+            # registry URL and hash are checked separately in this loop.
+            container = path
+            while True:
+                container = container.rpartition("/node_modules/")[0]
+                parent = packages.get(container)
+                if not container or parent is None:
+                    raise ValueError("Bundled dependencies require a containing package")
+                if parent.get("inBundle") is not True:
+                    break
+            bundled = parent.get("bundleDependencies")
+            if not isinstance(bundled, list) or not bundled:
+                raise ValueError("Containing package must declare bundled dependencies")
+            continue
+        url = urlsplit(package.get("resolved", ""))
+        if (url.scheme != "https" or url.netloc != "registry.npmjs.org"
+                or url.query or url.fragment
+                or not re.fullmatch(r"sha512-[A-Za-z0-9+/]+={0,2}", package.get("integrity", ""))):
+            raise ValueError("Dependencies must be integrity-pinned npm registry tarballs")
+
+
+def index_environment(directory):
+    return {
+        **os.environ,
+        "GIT_DIR": git("rev-parse", "--absolute-git-dir").decode().strip(),
+        "GIT_WORK_TREE": str(directory),
+        "GIT_INDEX_FILE": str(directory / "index"),
+    }
+
+
+def validate_tree(head, tree):
+    paths = git("diff-tree", "--no-commit-id", "--name-only", "--no-renames", "-r", "-z", head, tree).decode().split("\0")
+    if any(not vendor_path(path) for path in paths if path):
+        raise ValueError("The generated change must only touch node_modules")
+    for entry in git("ls-tree", "-r", "-z", tree, "--", "node_modules").split(b"\0"):
+        if entry and entry.split(b" ", 2)[:2] not in ([b"100644", b"blob"], [b"100755", b"blob"]):
+            raise ValueError("Vendored dependencies must be regular files")
+    return any(paths)
+
+
+def generate(patch):
+    head = sha(os.environ["PR_HEAD"])
+    git("fetch", "--no-tags", "--recurse-submodules=no", "origin", head)
+    manifest = git("show", f"{head}:package.json")
+    lock = git("show", f"{head}:package-lock.json")
+    validate_lock(json.loads(manifest), json.loads(lock))
+    with tempfile.TemporaryDirectory() as temporary:
+        directory = Path(temporary)
+        (directory / "package.json").write_bytes(manifest)
+        (directory / "package-lock.json").write_bytes(lock)
+        # Only configuration from the trusted checkout is used by npm and Git.
+        for name in (".gitignore", ".npmrc"):
+            (directory / name).write_bytes(Path(name).read_bytes())
+        subprocess.run(["npm", "ci", "--ignore-scripts", "--omit=dev", "--no-audit", "--no-fund"], cwd=directory, check=True)
+        env = index_environment(directory)
+        git("read-tree", head, env=env)
+        git("add", "--all", "--", "node_modules", env=env)
+        tree = git("write-tree", env=env).decode().strip()
+        changed = validate_tree(head, tree)
+        Path(patch).write_bytes(git("diff", "--cached", "--binary", "--full-index", head, "--", "node_modules", env=env))
+    output("changed", str(changed).lower())
+
+
+def current_pr():
+    repository = os.environ["GITHUB_REPOSITORY"]
+    number = os.environ["PR_NUMBER"]
+    if not re.fullmatch(r"[1-9][0-9]*", number):
+        raise ValueError("Invalid pull request number")
+    head = sha(os.environ["PR_HEAD"])
+    branch = os.environ["PR_BRANCH"]
+    git("check-ref-format", f"refs/heads/{branch}")
+    pr = api(f"repos/{repository}/pulls/{number}")
+    if not eligible(pr, repository, os.environ["DEFAULT_BRANCH"], head) or pr["head"]["ref"] != branch:
+        print("Pull request changed or closed; skipping the outdated vendor update.")
+        return False
+    return True
+
+
+def prepare(patch):
+    if not current_pr():
+        output("changed", "false")
+        return
+    head = sha(os.environ["PR_HEAD"])
+    git("fetch", "--no-tags", "--recurse-submodules=no", "origin", head)
+    with tempfile.TemporaryDirectory() as temporary:
+        env = index_environment(Path(temporary))
+        git("read-tree", head, env=env)
+        # Apply to the index only; PR files never replace the trusted checkout.
+        git("apply", "--cached", "--whitespace=nowarn", str(Path(patch).resolve()), env=env)
+        tree = git("write-tree", env=env).decode().strip()
+    changed = validate_tree(head, tree)
+    output("tree", tree)
+    output("changed", str(changed).lower())
+
+
+def publish():
+    if not current_pr():
+        return
+    head = sha(os.environ["PR_HEAD"])
+    tree = sha(os.environ["VENDOR_TREE"])
+    if not validate_tree(head, tree):
+        return
+    commit = git("commit-tree", "-S", tree, "-p", head, "-m", "node_modules: update", "-m", "[dependabot skip]").decode().strip()
+    credentials = base64.b64encode(f"x-access-token:{os.environ['GH_TOKEN']}".encode()).decode()
+    print(f"::add-mask::{credentials}", flush=True)
+    env = {
+        **os.environ,
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.https://github.com/.extraheader",
+        "GIT_CONFIG_VALUE_0": f"AUTHORIZATION: basic {credentials}",
+    }
+    ref = f"refs/heads/{os.environ['PR_BRANCH']}"
+    # The commit has exactly this parent. The explicit lease makes the update
+    # atomic even if the PR is rebased between the API check and the push.
+    git("push", f"--force-with-lease={ref}:{head}", "origin", f"{commit}:{ref}", env=env)
+
+
+if __name__ == "__main__":
+    try:
+        {"select": select, "generate": generate, "prepare": prepare, "publish": publish}[sys.argv[1]](*sys.argv[2:])
+    except subprocess.CalledProcessError as error:
+        sys.exit(error.returncode)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Test dependency automation
+        run: python3 -B -m unittest discover -s .github/scripts -p 'test_*.py'
+
       - name: Check vendored dependencies
         run: bash .github/scripts/check-node-modules.sh
 

--- a/.github/workflows/vendor-node-modules.yml
+++ b/.github/workflows/vendor-node-modules.yml
@@ -1,67 +1,128 @@
 name: Vendor node_modules
 
-on:
-  pull_request:
-    types:
-      - labeled
+# This follow-up runs trusted automation and consumes an artifact generated in
+# this run. PR code is never checked out or executed, including when publishing.
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: [Node test]
+    types: [completed]
   workflow_dispatch:
     inputs:
       pull_request:
         description: Pull request number
         required: true
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
+
+concurrency:
+  # Older test completions must not replace work queued for a newer head.
+  group: vendor-node-modules-${{ github.event.workflow_run.head_sha || inputs.pull_request }}
+  cancel-in-progress: false
 
 jobs:
-  vendor-node-modules:
+  generate:
     if: >
       github.repository_owner == 'Homebrew' && (
         github.event_name == 'workflow_dispatch' ||
-        contains(github.event.pull_request.labels.*.name, 'update node_modules')
+        github.event.workflow_run.event == 'pull_request'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      pull_request: ${{ steps.select.outputs.pull_request }}
+      head: ${{ steps.select.outputs.head }}
+      branch: ${{ steps.select.outputs.branch }}
+      changed: ${{ steps.generate.outputs.changed }}
+      artifact: ${{ steps.upload.outputs.artifact-id }}
     steps:
-      - name: Checkout
+      - name: Check out trusted automation
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+
+      - name: Select current pull request
+        id: select
+        run: python3 -B .github/scripts/vendor_node_modules.py select
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Set up Node
+        if: steps.select.outputs.selected == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
+          package-manager-cache: false
+
+      - name: Generate dependency changes
+        if: steps.select.outputs.selected == 'true'
+        id: generate
+        run: python3 -B .github/scripts/vendor_node_modules.py generate "$RUNNER_TEMP/vendor.patch"
+        env:
+          PR_HEAD: ${{ steps.select.outputs.head }}
+
+      - name: Upload dependency changes
+        if: steps.generate.outputs.changed == 'true'
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vendor-node-modules
+          path: ${{ runner.temp }}/vendor.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: generate
+    if: needs.generate.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
+    env:
+      PR_NUMBER: ${{ needs.generate.outputs.pull_request }}
+      PR_HEAD: ${{ needs.generate.outputs.head }}
+      PR_BRANCH: ${{ needs.generate.outputs.branch }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - name: Check out trusted automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Download dependency changes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.generate.outputs.artifact }}
+          path: ${{ runner.temp }}/vendor
+          merge-multiple: true
+
+      - name: Validate changes against the current pull request
+        id: prepare
+        run: python3 -B .github/scripts/vendor_node_modules.py prepare "$RUNNER_TEMP/vendor/vendor.patch"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Configure Git user
+        if: steps.prepare.outputs.changed == 'true'
         uses: $/git-user-config
         with:
           username: BrewTestBot
+
       - name: Set up commit signing
+        if: steps.prepare.outputs.changed == 'true'
         uses: $/setup-commit-signing
         with:
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
-      - name: Check out pull request
-        id: checkout
-        run: |
-          gh pr checkout "$PR"
 
-          branch="$(git branch --show-current)"
-          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+      - name: Publish dependency commit
+        if: steps.prepare.outputs.changed == 'true'
+        run: python3 -B .github/scripts/vendor_node_modules.py publish
         env:
-          PR: ${{ github.event.pull_request.number || github.event.inputs.pull_request }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Vendor node_modules
-        run: npm ci --ignore-scripts --omit=dev
-      - name: Commit changes
-        id: commit
-        run: |
-          if ! git diff --stat --exit-code node_modules; then
-            git add node_modules
-            git commit -m "node_modules: update"
-            echo "committed=true" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Push to pull request
-        if: steps.commit.outputs.committed == 'true'
-        uses: $/git-try-push
-        with:
-          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
-          branch: ${{ steps.checkout.outputs.branch }}
-          force: true
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          VENDOR_TREE: ${{ steps.prepare.outputs.tree }}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ To update dependencies for all Actions at once, one needs to simply run `npm upg
 Production dependencies are committed in `node_modules`. After changing the lockfile,
 run `npm ci --ignore-scripts --omit=dev` and commit the resulting dependency changes.
 The required Node test checks that these files match the lockfile before installing development dependencies.
+Dependabot npm PRs receive a vendor update automatically after the Node test completes.
+For other PRs from this repository, dispatch the `Vendor node_modules` workflow with the PR number.
+The updater accepts dependencies from the npm registry only.
 
 Workflow names match Actions' directory names, for consistency.
 Particular workflow to test an Action is run only when this Action's directory contents or workflow file are changed.


### PR DESCRIPTION
Dependabot cannot regenerate the committed `node_modules`, so every npm update now fails the vendored dependency check.

This replaces the label workflow with a `workflow_run` follow-up to the Node test. A job without credentials installs the PR's lockfile with scripts disabled and uploads the `node_modules` diff; a second job applies it to an isolated index and pushes a signed commit onto the PR head with `--force-with-lease`. PR code never runs alongside the signing key or push token, and generated commits carry `[dependabot skip]` so Dependabot can still rebase.

`workflow_dispatch` with a PR number remains available for other pull requests.

Claude Code (Fable 5.1) drafted the automation; I reviewed the diff and verified generation, signing and the push lease against local repositories.
